### PR TITLE
Simplify and speed up Object FindKey

### DIFF
--- a/ndjson_test.go
+++ b/ndjson_test.go
@@ -583,37 +583,42 @@ func BenchmarkNdjsonColdCountStarWithWhere(b *testing.B) {
 func BenchmarkNdjsonWarmCountStar(b *testing.B) {
 	ndjson := loadFile("testdata/parking-citations-1M.json.zst")
 
-	pj := internalParsedJson{}
-	pj.parseMessage(ndjson)
-
+	pj, err := ParseND(ndjson, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
 	b.SetBytes(int64(len(ndjson)))
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		countObjects(pj.ParsedJson)
+		countObjects(*pj)
 	}
 }
 
 func BenchmarkNdjsonWarmCountStarWithWhere(b *testing.B) {
 	ndjson := loadFile("testdata/parking-citations-1M.json.zst")
 
-	pj := internalParsedJson{}
-	pj.parseMessage(ndjson)
+	pj, err := ParseND(ndjson, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.Run("raw", func(b *testing.B) {
+		b.Skip("@fwessels - this crashes...")
 		b.SetBytes(int64(len(ndjson)))
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			countRawTapeWhere("Make", "HOND", pj.ParsedJson)
+			countRawTapeWhere("Make", "HOND", *pj)
 		}
 	})
 	b.Run("iter", func(b *testing.B) {
 		b.SetBytes(int64(len(ndjson)))
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			countWhere("Make", "HOND", pj.ParsedJson)
+			countWhere("Make", "HOND", *pj)
 		}
 	})
-
 }


### PR DESCRIPTION
Use the length to reject candidates a bit quicker.

```
λ benchcmp before.txt after.txt
benchmark                                         old ns/op     new ns/op     delta
BenchmarkNdjsonWarmCountStarWithWhere/iter-12     272527765     251116358     -7.86%

benchmark                                         old MB/s           new MB/s           speedup
BenchmarkNdjsonWarmCountStarWithWhere/iter-12     1341.11            1455.46            1.09x
```

`countRawTapeWhere` is broken. I don't know if there is any point in fixing it. Old benchmark was broken.