### PR TITLE
all: run asmfmt

### DIFF
--- a/finalize_structurals_amd64.s
+++ b/finalize_structurals_amd64.s
@@ -5,54 +5,54 @@
 
 TEXT ·_finalize_structurals(SB), $0-48
 
-    MOVQ structurals_in+0(FP), DI
-    MOVQ whitespace+8(FP), SI
-    MOVQ quote_mask+16(FP), DX
-    MOVQ quote_bits+24(FP), CX
-    MOVQ prev_iter_ends_pseudo_pred+32(FP), R8
+	MOVQ structurals_in+0(FP), DI
+	MOVQ whitespace+8(FP), SI
+	MOVQ quote_mask+16(FP), DX
+	MOVQ quote_bits+24(FP), CX
+	MOVQ prev_iter_ends_pseudo_pred+32(FP), R8
 
-    CALL ·__finalize_structurals(SB)
+	CALL ·__finalize_structurals(SB)
 
-    MOVQ AX, structurals+40(FP)
-    RET
+	MOVQ AX, structurals+40(FP)
+	RET
 
 TEXT ·__finalize_structurals(SB), $0
 
-    ANDNQ DI, DX, DI             // andn    rdi, rdx, rdi
-    ORQ  CX, DI                  // or    rdi, rcx
-    MOVQ DI, AX                  // mov    rax, rdi
-    ORQ  SI, AX                  // or    rax, rsi
-    LEAQ (AX)(AX*1), R9          // lea    r9, [rax + rax]
-    ORQ  (R8), R9                // or    r9, qword [r8]
-    SHRQ $63, AX                 // shr    rax, 63
-    MOVQ AX, (R8)                // mov    qword [r8], rax
-    NOTQ SI                      // not    rsi
-    ANDNQ SI, DX, AX             // andn    rax, rdx, rsi
-    ANDQ R9, AX                  // and    rax, r9
-    ORQ  DI, AX                  // or    rax, rdi
-    NOTQ CX                      // not    rcx
-    ORQ  DX, CX                  // or    rcx, rdx
-    ANDQ CX, AX                  // and    rax, rcx
-    RET
+	ANDNQ DI, DX, DI     // andn    rdi, rdx, rdi
+	ORQ   CX, DI         // or    rdi, rcx
+	MOVQ  DI, AX         // mov    rax, rdi
+	ORQ   SI, AX         // or    rax, rsi
+	LEAQ  (AX)(AX*1), R9 // lea    r9, [rax + rax]
+	ORQ   (R8), R9       // or    r9, qword [r8]
+	SHRQ  $63, AX        // shr    rax, 63
+	MOVQ  AX, (R8)       // mov    qword [r8], rax
+	NOTQ  SI             // not    rsi
+	ANDNQ SI, DX, AX     // andn    rax, rdx, rsi
+	ANDQ  R9, AX         // and    rax, r9
+	ORQ   DI, AX         // or    rax, rdi
+	NOTQ  CX             // not    rcx
+	ORQ   DX, CX         // or    rcx, rdx
+	ANDQ  CX, AX         // and    rax, rcx
+	RET
 
 TEXT ·__finalize_structurals_avx512(SB), $0
 
-    KMOVQ K_WHITESPACE,  SI
-    KMOVQ K_QUOTEBITS,   CX
-    KMOVQ K_STRUCTURALS, DI
-    ANDNQ DI, DX, DI             // andn    rdi, rdx, rdi
-    ORQ  CX, DI                  // or    rdi, rcx
-    MOVQ DI, AX                  // mov    rax, rdi
-    ORQ  SI, AX                  // or    rax, rsi
-    LEAQ (AX)(AX*1), R9          // lea    r9, [rax + rax]
-    ORQ  (R8), R9                // or    r9, qword [r8]
-    SHRQ $63, AX                 // shr    rax, 63
-    MOVQ AX, (R8)                // mov    qword [r8], rax
-    NOTQ SI                      // not    rsi
-    ANDNQ SI, DX, AX             // andn    rax, rdx, rsi
-    ANDQ R9, AX                  // and    rax, r9
-    ORQ  DI, AX                  // or    rax, rdi
-    NOTQ CX                      // not    rcx
-    ORQ  DX, CX                  // or    rcx, rdx
-    ANDQ CX, AX                  // and    rax, rcx
-    RET
+	KMOVQ K_WHITESPACE, SI
+	KMOVQ K_QUOTEBITS, CX
+	KMOVQ K_STRUCTURALS, DI
+	ANDNQ DI, DX, DI        // andn    rdi, rdx, rdi
+	ORQ   CX, DI            // or    rdi, rcx
+	MOVQ  DI, AX            // mov    rax, rdi
+	ORQ   SI, AX            // or    rax, rsi
+	LEAQ  (AX)(AX*1), R9    // lea    r9, [rax + rax]
+	ORQ   (R8), R9          // or    r9, qword [r8]
+	SHRQ  $63, AX           // shr    rax, 63
+	MOVQ  AX, (R8)          // mov    qword [r8], rax
+	NOTQ  SI                // not    rsi
+	ANDNQ SI, DX, AX        // andn    rax, rdx, rsi
+	ANDQ  R9, AX            // and    rax, r9
+	ORQ   DI, AX            // or    rax, rdi
+	NOTQ  CX                // not    rcx
+	ORQ   DX, CX            // or    rcx, rdx
+	ANDQ  CX, AX            // and    rax, rcx
+	RET

--- a/find_newline_delimiters_amd64.s
+++ b/find_newline_delimiters_amd64.s
@@ -2,16 +2,16 @@
 
 // _find_newline_delimiters(raw []byte) (mask uint64)
 TEXT ·_find_newline_delimiters(SB), 7, $0
-	MOVQ    raw+0(FP), SI         // SI: &raw
-	MOVQ    quoteMask+24(FP), DX  // get quotemask
-    VMOVDQU (SI), Y8              // load low 32-bytes
-    VMOVDQU 0x20(SI), Y9          // load high 32-bytes
+	MOVQ    raw+0(FP), SI        // SI: &raw
+	MOVQ    quoteMask+24(FP), DX // get quotemask
+	VMOVDQU (SI), Y8             // load low 32-bytes
+	VMOVDQU 0x20(SI), Y9         // load high 32-bytes
 
-    CALL ·__find_newline_delimiters(SB)
+	CALL ·__find_newline_delimiters(SB)
 
-	MOVQ    BX, mask+32(FP)       // store result
+	MOVQ BX, mask+32(FP) // store result
 	VZEROUPPER
-    RET
+	RET
 
 TEXT ·__find_newline_delimiters(SB), 7, $0
 	MOVQ         $0x0a, BX // get newline
@@ -23,33 +23,32 @@ TEXT ·__find_newline_delimiters(SB), 7, $0
 	VPMOVMSKB Y10, BX
 	VPMOVMSKB Y11, CX
 	SHLQ      $32, CX
-	ORQ       CX, BX          // BX is resulting mask of newline chars
-	ANDNQ     BX, DX, BX      // clear out newline delimiters enclosed in quotes
+	ORQ       CX, BX       // BX is resulting mask of newline chars
+	ANDNQ     BX, DX, BX   // clear out newline delimiters enclosed in quotes
 	RET
-
 
 // _find_newline_delimiters_avx512(raw []byte) (mask uint64)
 TEXT ·_find_newline_delimiters_avx512(SB), 7, $0
-	MOVQ      raw+0(FP), SI         // SI: &raw
-	MOVQ      quoteMask+24(FP), DX  // get quotemask
-    VMOVDQU32 (SI), Z8              // load 64 bytes
+	MOVQ      raw+0(FP), SI        // SI: &raw
+	MOVQ      quoteMask+24(FP), DX // get quotemask
+	VMOVDQU32 (SI), Z8             // load 64 bytes
 
-    CALL ·__init_newline_delimiters_avx512(SB)
-    CALL ·__find_newline_delimiters_avx512(SB)
+	CALL ·__init_newline_delimiters_avx512(SB)
+	CALL ·__find_newline_delimiters_avx512(SB)
 
-	MOVQ    BX, mask+32(FP)       // store result
+	MOVQ BX, mask+32(FP) // store result
 	VZEROUPPER
-    RET
+	RET
 
 #define NLD_CONST Z26
 
 TEXT ·__init_newline_delimiters_avx512(SB), 7, $0
-	MOVQ         $0x0a, BX // get newline
+	MOVQ         $0x0a, BX     // get newline
 	VPBROADCASTB BX, NLD_CONST
 	RET
 
 TEXT ·__find_newline_delimiters_avx512(SB), 7, $0
-	VPCMPEQB  Z8, NLD_CONST, K1
-	KMOVQ     K1, BX
-	ANDNQ     BX, DX, BX      // clear out newline delimiters enclosed in quotes
-    RET
+	VPCMPEQB Z8, NLD_CONST, K1
+	KMOVQ    K1, BX
+	ANDNQ    BX, DX, BX        // clear out newline delimiters enclosed in quotes
+	RET

--- a/find_odd_backslash_sequences_amd64.s
+++ b/find_odd_backslash_sequences_amd64.s
@@ -23,13 +23,13 @@ TEXT ·_find_odd_backslash_sequences(SB), $0-24
 
 TEXT ·__find_odd_backslash_sequences(SB), $0
 	LEAQ      LCDATA1<>(SB), BP
-	VMOVDQA   (BP), Y0            // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
-	VPCMPEQB  Y8/*(DI)*/, Y0, Y1  // vpcmpeqb    ymm1, ymm0, yword [rdi]
-	VPMOVMSKB Y1, CX              // vpmovmskb    ecx, ymm1
-	VPCMPEQB  Y9/*(SI)*/, Y0, Y0  // vpcmpeqb    ymm0, ymm0, yword [rsi]
-	VPMOVMSKB Y0, AX              // vpmovmskb    eax, ymm0
-	SHLQ      $32, AX             // shl    rax, 32
-	ORQ       CX, AX              // or    rax, rcx
+	VMOVDQA   (BP), Y0           // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
+	VPCMPEQB  Y8/*(DI)*/, Y0, Y1 // vpcmpeqb    ymm1, ymm0, yword [rdi]
+	VPMOVMSKB Y1, CX             // vpmovmskb    ecx, ymm1
+	VPCMPEQB  Y9/*(SI)*/, Y0, Y0 // vpcmpeqb    ymm0, ymm0, yword [rsi]
+	VPMOVMSKB Y0, AX             // vpmovmskb    eax, ymm0
+	SHLQ      $32, AX            // shl    rax, 32
+	ORQ       CX, AX             // or    rax, rcx
 
 #define FIND_ODD_BACKSLASH_SEQUENCES \
 	LEAQ  (AX)(AX*1), CX           \ // lea    rcx, [rax + rax]

--- a/find_odd_backslash_sequences_amd64.s
+++ b/find_odd_backslash_sequences_amd64.s
@@ -9,81 +9,80 @@ GLOBL LCDATA1<>(SB), 8, $32
 
 TEXT ·_find_odd_backslash_sequences(SB), $0-24
 
-    MOVQ p1+0(FP), DI
-    MOVQ p3+8(FP), DX
+	MOVQ p1+0(FP), DI
+	MOVQ p3+8(FP), DX
 
-    VMOVDQU    (DI), Y8          // load low 32-bytes
-    VMOVDQU    0x20(DI), Y9      // load high 32-bytes
+	VMOVDQU (DI), Y8     // load low 32-bytes
+	VMOVDQU 0x20(DI), Y9 // load high 32-bytes
 
-    CALL ·__find_odd_backslash_sequences(SB)
+	CALL ·__find_odd_backslash_sequences(SB)
 
-    VZEROUPPER
-    MOVQ AX, result+16(FP)
-    RET
-
+	VZEROUPPER
+	MOVQ AX, result+16(FP)
+	RET
 
 TEXT ·__find_odd_backslash_sequences(SB), $0
-    LEAQ LCDATA1<>(SB), BP
-    VMOVDQA (BP), Y0             // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
-    VPCMPEQB Y8/*(DI)*/, Y0, Y1  // vpcmpeqb    ymm1, ymm0, yword [rdi]
-    VPMOVMSKB Y1, CX             // vpmovmskb    ecx, ymm1
-    VPCMPEQB Y9/*(SI)*/, Y0, Y0  // vpcmpeqb    ymm0, ymm0, yword [rsi]
-    VPMOVMSKB Y0, AX             // vpmovmskb    eax, ymm0
-    SHLQ $32, AX                 // shl    rax, 32
-    ORQ  CX, AX                  // or    rax, rcx
+	LEAQ      LCDATA1<>(SB), BP
+	VMOVDQA   (BP), Y0            // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
+	VPCMPEQB  Y8/*(DI)*/, Y0, Y1  // vpcmpeqb    ymm1, ymm0, yword [rdi]
+	VPMOVMSKB Y1, CX              // vpmovmskb    ecx, ymm1
+	VPCMPEQB  Y9/*(SI)*/, Y0, Y0  // vpcmpeqb    ymm0, ymm0, yword [rsi]
+	VPMOVMSKB Y0, AX              // vpmovmskb    eax, ymm0
+	SHLQ      $32, AX             // shl    rax, 32
+	ORQ       CX, AX              // or    rax, rcx
 
 #define FIND_ODD_BACKSLASH_SEQUENCES \
-    LEAQ (AX)(AX*1), CX          \ // lea    rcx, [rax + rax]
-    NOTQ CX                      \ // not    rcx
-    ANDQ AX, CX                  \ // and    rcx, rax
-    WORD $0x8b4c; BYTE $0x0a     \ // mov    r9, qword [rdx]
-    MOVQ $0x5555555555555555, R8 \ // mov    r8, 6148914691236517205
-    MOVQ R9, SI                  \ // mov    rsi, r9
-    XORQ R8, SI                  \ // xor    rsi, r8
-    ANDQ CX, SI                  \ // and    rsi, rcx
-    MOVQ $0xaaaaaaaaaaaaaaaa, R10 \ // mov    r10, -6148914691236517206
-    MOVQ R9, DI                  \ // mov    rdi, r9
-    XORQ R10, DI                 \ // xor    rdi, r10
-    ANDQ CX, DI                  \ // and    rdi, rcx
-    ADDQ AX, SI                  \ // add    rsi, rax
-    XORL CX, CX                  \ // xor    ecx, ecx
-    ADDQ AX, DI                  \ // add    rdi, rax
-    SETCS CX                     \ // setb    cl
-    ORQ  R9, DI                  \ // or    rdi, r9
-    MOVQ CX, (DX)                \ // mov    qword [rdx], rcx
-    NOTQ AX                      \ // not    rax
-    ANDQ AX, R10                 \ // and    r10, rax
-    ANDQ SI, R10                 \ // and    r10, rsi
-    ANDQ R8, AX                  \ // and    rax, r8
-    ANDQ DI, AX                  \ // and    rax, rdi
-    ORQ  R10, AX                   // or    rax, r10
+	LEAQ  (AX)(AX*1), CX           \ // lea    rcx, [rax + rax]
+	NOTQ  CX                       \ // not    rcx
+	ANDQ  AX, CX                   \ // and    rcx, rax
+	WORD  $0x8b4c; BYTE $0x0a      \ // mov    r9, qword [rdx]
+	MOVQ  $0x5555555555555555, R8  \ // mov    r8, 6148914691236517205
+	MOVQ  R9, SI                   \ // mov    rsi, r9
+	XORQ  R8, SI                   \ // xor    rsi, r8
+	ANDQ  CX, SI                   \ // and    rsi, rcx
+	MOVQ  $0xaaaaaaaaaaaaaaaa, R10 \ // mov    r10, -6148914691236517206
+	MOVQ  R9, DI                   \ // mov    rdi, r9
+	XORQ  R10, DI                  \ // xor    rdi, r10
+	ANDQ  CX, DI                   \ // and    rdi, rcx
+	ADDQ  AX, SI                   \ // add    rsi, rax
+	XORL  CX, CX                   \ // xor    ecx, ecx
+	ADDQ  AX, DI                   \ // add    rdi, rax
+	SETCS CX                       \ // setb    cl
+	ORQ   R9, DI                   \ // or    rdi, r9
+	MOVQ  CX, (DX)                 \ // mov    qword [rdx], rcx
+	NOTQ  AX                       \ // not    rax
+	ANDQ  AX, R10                  \ // and    r10, rax
+	ANDQ  SI, R10                  \ // and    r10, rsi
+	ANDQ  R8, AX                   \ // and    rax, r8
+	ANDQ  DI, AX                   \ // and    rax, rdi
+	ORQ   R10, AX                  // or    rax, r10
 
-    FIND_ODD_BACKSLASH_SEQUENCES
-    RET
+	FIND_ODD_BACKSLASH_SEQUENCES
+	RET
 
 #define OBSS_CONST Z16
 
 TEXT ·_find_odd_backslash_sequences_avx512(SB), $0-24
 
-    MOVQ p1+0(FP), DI
-    MOVQ p3+8(FP), DX
+	MOVQ p1+0(FP), DI
+	MOVQ p3+8(FP), DX
 
-    VMOVDQU32    (DI), Z8
+	VMOVDQU32 (DI), Z8
 
-    CALL ·__init_odd_backslash_sequences_avx512(SB)
-    CALL ·__find_odd_backslash_sequences_avx512(SB)
+	CALL ·__init_odd_backslash_sequences_avx512(SB)
+	CALL ·__find_odd_backslash_sequences_avx512(SB)
 
-    VZEROUPPER
-    MOVQ AX, result+16(FP)
-    RET
+	VZEROUPPER
+	MOVQ AX, result+16(FP)
+	RET
 
 TEXT ·__init_odd_backslash_sequences_avx512(SB), $0
-    MOVQ         $0x5c, AX
-    VPBROADCASTB AX, OBSS_CONST
-    RET
+	MOVQ         $0x5c, AX
+	VPBROADCASTB AX, OBSS_CONST
+	RET
 
 TEXT ·__find_odd_backslash_sequences_avx512(SB), $0
-    VPCMPEQB     Z8, OBSS_CONST, K1
-    KMOVQ        K1, AX
-    FIND_ODD_BACKSLASH_SEQUENCES
-    RET
+	VPCMPEQB Z8, OBSS_CONST, K1
+	KMOVQ    K1, AX
+	FIND_ODD_BACKSLASH_SEQUENCES
+	RET

--- a/find_quote_mask_and_bits_amd64.s
+++ b/find_quote_mask_and_bits_amd64.s
@@ -31,106 +31,105 @@ GLOBL LCDATA1<>(SB), 8, $192
 
 TEXT ·_find_quote_mask_and_bits(SB), $0-48
 
-    MOVQ input+0(FP), DI
-    MOVQ odd_ends+8(FP), DX
-    MOVQ prev_iter_inside_quote+16(FP), CX
-    MOVQ quote_bits+24(FP), R8
-    MOVQ error_mask+32(FP), R9
+	MOVQ input+0(FP), DI
+	MOVQ odd_ends+8(FP), DX
+	MOVQ prev_iter_inside_quote+16(FP), CX
+	MOVQ quote_bits+24(FP), R8
+	MOVQ error_mask+32(FP), R9
 
-    VMOVDQU    (DI), Y8          // load low 32-bytes
-    VMOVDQU    0x20(DI), Y9      // load high 32-bytes
+	VMOVDQU (DI), Y8     // load low 32-bytes
+	VMOVDQU 0x20(DI), Y9 // load high 32-bytes
 
-    CALL ·__find_quote_mask_and_bits(SB)
+	CALL ·__find_quote_mask_and_bits(SB)
 
-    VZEROUPPER
-    MOVQ AX, quote_mask+40(FP)
-    RET
-
+	VZEROUPPER
+	MOVQ AX, quote_mask+40(FP)
+	RET
 
 TEXT ·__find_quote_mask_and_bits(SB), $0
-    LEAQ LCDATA1<>(SB), BP
+	LEAQ LCDATA1<>(SB), BP
 
-    VMOVDQA    Y8, Y0            // vmovdqu    ymm0, yword [rdi]
-    VMOVDQA    Y9, Y1            // vmovdqu    ymm1, yword [rsi]
-    VMOVDQA    (BP), Y2          // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
-    VPCMPEQB   Y2, Y0, Y3        // vpcmpeqb    ymm3, ymm0, ymm2
-    VPMOVMSKB  Y3, AX            // vpmovmskb    eax, ymm3
-    VPCMPEQB   Y2, Y1, Y2        // vpcmpeqb    ymm2, ymm1, ymm2
-    VPMOVMSKB  Y2, SI            // vpmovmskb    esi, ymm2
-    SHLQ       $32, SI           // shl    rsi, 32
-    ORQ        AX, SI            // or    rsi, rax
-    NOTQ       DX                // not    rdx
-    ANDQ       SI, DX            // and    rdx, rsi
-    MOVQ       DX, (R8)          // mov    qword [r8], rdx
-    VMOVQ      DX, X2            // vmovq    xmm2, rdx
-    VPCMPEQD   X3, X3, X3        // vpcmpeqd    xmm3, xmm3, xmm3
-    VPCLMULQDQ $0, X3, X2, X2    // vpclmulqdq    xmm2, xmm2, xmm3, 0
-    VMOVQ      X2, AX            // vmovq    rax, xmm2
-    XORQ       (CX), AX          // xor    rax, qword [rcx]
-    VMOVDQA    0x40(BP), Y2      // vmovdqa    ymm2, yword 32[rbp] /* [rip + LCPI0_1] */
-    VPXOR      Y2, Y0, Y0        // vpxor    ymm0, ymm0, ymm2
-    VMOVDQA    0x80(BP), Y3      // vmovdqa    ymm3, yword 64[rbp] /* [rip + LCPI0_2] */
-    VPCMPGTB   Y0, Y3, Y0        // vpcmpgtb    ymm0, ymm3, ymm0
-    VPMOVMSKB  Y0, DX            // vpmovmskb    edx, ymm0
-    VPXOR      Y2, Y1, Y0        // vpxor    ymm0, ymm1, ymm2
-    VPCMPGTB   Y0, Y3, Y0        // vpcmpgtb    ymm0, ymm3, ymm0
-    VPMOVMSKB  Y0, SI            // vpmovmskb    esi, ymm0
-    SHLQ       $32, SI           // shl    rsi, 32
-    ORQ        DX, SI            // or    rsi, rdx
-    ANDQ       AX, SI            // and    rsi, rax
-    ORQ        SI, (R9)          // or    qword [r9], rsi
-    MOVQ       AX, DX            // mov    rdx, rax
-    SARQ       $63, DX           // sar    rdx, 63
-    MOVQ       DX, (CX)          // mov    qword [rcx], rdx
-    RET
+	VMOVDQA    Y8, Y0         // vmovdqu    ymm0, yword [rdi]
+	VMOVDQA    Y9, Y1         // vmovdqu    ymm1, yword [rsi]
+	VMOVDQA    (BP), Y2       // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
+	VPCMPEQB   Y2, Y0, Y3     // vpcmpeqb    ymm3, ymm0, ymm2
+	VPMOVMSKB  Y3, AX         // vpmovmskb    eax, ymm3
+	VPCMPEQB   Y2, Y1, Y2     // vpcmpeqb    ymm2, ymm1, ymm2
+	VPMOVMSKB  Y2, SI         // vpmovmskb    esi, ymm2
+	SHLQ       $32, SI        // shl    rsi, 32
+	ORQ        AX, SI         // or    rsi, rax
+	NOTQ       DX             // not    rdx
+	ANDQ       SI, DX         // and    rdx, rsi
+	MOVQ       DX, (R8)       // mov    qword [r8], rdx
+	VMOVQ      DX, X2         // vmovq    xmm2, rdx
+	VPCMPEQD   X3, X3, X3     // vpcmpeqd    xmm3, xmm3, xmm3
+	VPCLMULQDQ $0, X3, X2, X2 // vpclmulqdq    xmm2, xmm2, xmm3, 0
+	VMOVQ      X2, AX         // vmovq    rax, xmm2
+	XORQ       (CX), AX       // xor    rax, qword [rcx]
+	VMOVDQA    0x40(BP), Y2   // vmovdqa    ymm2, yword 32[rbp] /* [rip + LCPI0_1] */
+	VPXOR      Y2, Y0, Y0     // vpxor    ymm0, ymm0, ymm2
+	VMOVDQA    0x80(BP), Y3   // vmovdqa    ymm3, yword 64[rbp] /* [rip + LCPI0_2] */
+	VPCMPGTB   Y0, Y3, Y0     // vpcmpgtb    ymm0, ymm3, ymm0
+	VPMOVMSKB  Y0, DX         // vpmovmskb    edx, ymm0
+	VPXOR      Y2, Y1, Y0     // vpxor    ymm0, ymm1, ymm2
+	VPCMPGTB   Y0, Y3, Y0     // vpcmpgtb    ymm0, ymm3, ymm0
+	VPMOVMSKB  Y0, SI         // vpmovmskb    esi, ymm0
+	SHLQ       $32, SI        // shl    rsi, 32
+	ORQ        DX, SI         // or    rsi, rdx
+	ANDQ       AX, SI         // and    rsi, rax
+	ORQ        SI, (R9)       // or    qword [r9], rsi
+	MOVQ       AX, DX         // mov    rdx, rax
+	SARQ       $63, DX        // sar    rdx, 63
+	MOVQ       DX, (CX)       // mov    qword [rcx], rdx
+	RET
 
 TEXT ·_find_quote_mask_and_bits_avx512(SB), $0-48
 
-    MOVQ input+0(FP), DI
-    MOVQ odd_ends+8(FP), DX
-    MOVQ prev_iter_inside_quote+16(FP), CX
+	MOVQ input+0(FP), DI
+	MOVQ odd_ends+8(FP), DX
+	MOVQ prev_iter_inside_quote+16(FP), CX
 
-    KORQ K_ERRORMASK, K_ERRORMASK, K_ERRORMASK
+	KORQ K_ERRORMASK, K_ERRORMASK, K_ERRORMASK
 
-    VMOVDQU32    (DI), Z8
+	VMOVDQU32 (DI), Z8
 
-    CALL ·__init_quote_mask_and_bits_avx512(SB)
-    CALL ·__find_quote_mask_and_bits_avx512(SB)
+	CALL ·__init_quote_mask_and_bits_avx512(SB)
+	CALL ·__find_quote_mask_and_bits_avx512(SB)
 
-    VZEROUPPER
-    KMOVQ K_ERRORMASK, error_mask+24(FP)
-    KMOVQ  K_QUOTEBITS, quote_bits+32(FP)
-    MOVQ AX, quote_mask+40(FP)
-    RET
+	VZEROUPPER
+	KMOVQ K_ERRORMASK, error_mask+24(FP)
+	KMOVQ K_QUOTEBITS, quote_bits+32(FP)
+	MOVQ  AX, quote_mask+40(FP)
+	RET
 
 #define QMAB_CONST1 Z17
 #define QMAB_CONST2 Z18
 #define QMAB_CONST3 Z19
 
 TEXT ·__init_quote_mask_and_bits_avx512(SB), $0
-    LEAQ LCDATA1<>(SB), BP
-    VMOVDQU32  0x00(BP), QMAB_CONST1
-    VMOVDQU32  0x40(BP), QMAB_CONST2
-    VMOVDQU32  0x80(BP), QMAB_CONST3
-    RET
+	LEAQ      LCDATA1<>(SB), BP
+	VMOVDQU32 0x00(BP), QMAB_CONST1
+	VMOVDQU32 0x40(BP), QMAB_CONST2
+	VMOVDQU32 0x80(BP), QMAB_CONST3
+	RET
 
 TEXT ·__find_quote_mask_and_bits_avx512(SB), $0
-    VPCMPEQB   QMAB_CONST1, Z8, K_QUOTEBITS
-    KMOVQ      DX, K_TEMP1
-    KNOTQ      K_TEMP1, K_TEMP1
-    KANDQ      K_TEMP1, K_QUOTEBITS, K_QUOTEBITS
-    KMOVQ      K_QUOTEBITS, DX
-    VMOVQ      DX, X2            // vmovq    xmm2, rdx
-    VPCMPEQD   X3, X3, X3        // vpcmpeqd    xmm3, xmm3, xmm3
-    VPCLMULQDQ $0, X3, X2, X2    // vpclmulqdq    xmm2, xmm2, xmm3, 0
-    VMOVQ      X2, AX            // vmovq    rax, xmm2
-    XORQ       (CX), AX          // xor    rax, qword [rcx]
-    VPXORD     QMAB_CONST2, Z8, Z0
-    VPCMPGTB   Z0, QMAB_CONST3, K_TEMP1 // vpcmpgtb    ymm0, ymm3, ymm0
-    KMOVQ      AX, K_TEMP2
-    KANDQ      K_TEMP2, K_TEMP1, K_TEMP1
-    KORQ       K_TEMP1, K_ERRORMASK, K_ERRORMASK
-    MOVQ       AX, DX            // mov    rdx, rax
-    SARQ       $63, DX           // sar    rdx, 63
-    MOVQ       DX, (CX)          // mov    qword [rcx], rdx
-    RET
+	VPCMPEQB   QMAB_CONST1, Z8, K_QUOTEBITS
+	KMOVQ      DX, K_TEMP1
+	KNOTQ      K_TEMP1, K_TEMP1
+	KANDQ      K_TEMP1, K_QUOTEBITS, K_QUOTEBITS
+	KMOVQ      K_QUOTEBITS, DX
+	VMOVQ      DX, X2                            // vmovq    xmm2, rdx
+	VPCMPEQD   X3, X3, X3                        // vpcmpeqd    xmm3, xmm3, xmm3
+	VPCLMULQDQ $0, X3, X2, X2                    // vpclmulqdq    xmm2, xmm2, xmm3, 0
+	VMOVQ      X2, AX                            // vmovq    rax, xmm2
+	XORQ       (CX), AX                          // xor    rax, qword [rcx]
+	VPXORD     QMAB_CONST2, Z8, Z0
+	VPCMPGTB   Z0, QMAB_CONST3, K_TEMP1          // vpcmpgtb    ymm0, ymm3, ymm0
+	KMOVQ      AX, K_TEMP2
+	KANDQ      K_TEMP2, K_TEMP1, K_TEMP1
+	KORQ       K_TEMP1, K_ERRORMASK, K_ERRORMASK
+	MOVQ       AX, DX                            // mov    rdx, rax
+	SARQ       $63, DX                           // sar    rdx, 63
+	MOVQ       DX, (CX)                          // mov    qword [rcx], rdx
+	RET

--- a/find_structural_bits_amd64.s
+++ b/find_structural_bits_amd64.s
@@ -2,159 +2,157 @@
 
 TEXT ·_find_structural_bits(SB), $0-72
 
-    MOVQ p1+0(FP), DI
-    MOVQ p3+8(FP), DX
+	MOVQ p1+0(FP), DI
+	MOVQ p3+8(FP), DX
 
-    VMOVDQU    (DI), Y8          // load low 32-bytes
-    VMOVDQU    0x20(DI), Y9      // load high 32-bytes
+	VMOVDQU (DI), Y8     // load low 32-bytes
+	VMOVDQU 0x20(DI), Y9 // load high 32-bytes
 
-    CALL ·__find_odd_backslash_sequences(SB)
+	CALL ·__find_odd_backslash_sequences(SB)
 
-    MOVQ AX, DX                  // odd_ends + 16
-    MOVQ prev_iter_inside_quote+16(FP), CX
-    MOVQ quote_bits+24(FP), R8
-    MOVQ error_mask+32(FP), R9
+	MOVQ AX, DX                            // odd_ends + 16
+	MOVQ prev_iter_inside_quote+16(FP), CX
+	MOVQ quote_bits+24(FP), R8
+	MOVQ error_mask+32(FP), R9
 
-    CALL ·__find_quote_mask_and_bits(SB)
-    PUSHQ AX                     //  MOVQ AX, quote_mask + 64
+	CALL  ·__find_quote_mask_and_bits(SB)
+	PUSHQ AX                              // MOVQ AX, quote_mask + 64
 
-    MOVQ whitespace+40(FP), DX
-    MOVQ structurals_in+48(FP), CX
+	MOVQ whitespace+40(FP), DX
+	MOVQ structurals_in+48(FP), CX
 
-    CALL ·__find_whitespace_and_structurals(SB)
+	CALL ·__find_whitespace_and_structurals(SB)
 
-    MOVQ structurals_in+48(FP), DI; MOVQ (DI), DI // DI = structurals
-    MOVQ whitespace+40(FP), SI; MOVQ (SI), SI     // SI = whitespace
-    POPQ DX                                       // DX = quote_mask
-    MOVQ quote_bits+24(FP), CX; MOVQ (CX), CX     // CX = quote_bits
-    MOVQ prev_iter_ends_pseudo_pred+56(FP), R8    // R8 = &prev_iter_ends_pseudo_pred
+	MOVQ structurals_in+48(FP), DI; MOVQ (DI), DI // DI = structurals
+	MOVQ whitespace+40(FP), SI; MOVQ (SI), SI     // SI = whitespace
+	POPQ DX                                       // DX = quote_mask
+	MOVQ quote_bits+24(FP), CX; MOVQ (CX), CX     // CX = quote_bits
+	MOVQ prev_iter_ends_pseudo_pred+56(FP), R8    // R8 = &prev_iter_ends_pseudo_pred
 
-    CALL ·__finalize_structurals(SB)
-    MOVQ AX, structurals+64(FP)
+	CALL ·__finalize_structurals(SB)
+	MOVQ AX, structurals+64(FP)
 
-    VZEROUPPER
-    RET
+	VZEROUPPER
+	RET
 
 #define MASK_WHITESPACE(MAX, Y) \
-    LEAQ MASKTABLE<>(SB), DX    \
-    MOVQ $MAX, BX               \
-    SUBQ CX, BX                 \
-    VMOVDQU  (DX)(BX*1), Y10    \ // Load mask
-    VPCMPEQB Y11, Y11, Y11      \ // Set all bits
-    VPXOR    Y11, Y10, Y12      \ // Invert mask
-    VPAND    Y13, Y12, Y12      \ // Mask whitespace
-    VPAND    Y10, Y,   Y        \ // Mask message
-    VPOR     Y12, Y,   Y          // Combine together
-
+	LEAQ     MASKTABLE<>(SB), DX \
+	MOVQ     $MAX, BX            \
+	SUBQ     CX, BX              \
+	VMOVDQU  (DX)(BX*1), Y10     \ // Load mask
+	VPCMPEQB Y11, Y11, Y11       \ // Set all bits
+	VPXOR    Y11, Y10, Y12       \ // Invert mask
+	VPAND    Y13, Y12, Y12       \ // Mask whitespace
+	VPAND    Y10, Y, Y           \ // Mask message
+	VPOR     Y12, Y, Y           // Combine together
 
 TEXT ·_find_structural_bits_in_slice(SB), $0-128
-    XORQ AX, AX
-    MOVQ len+8(FP), CX
-    ANDQ $0xffffffffffffffc0, CX
-    CMPQ  AX, CX
-    JEQ   check_partial_load
+	XORQ AX, AX
+	MOVQ len+8(FP), CX
+	ANDQ $0xffffffffffffffc0, CX
+	CMPQ AX, CX
+	JEQ  check_partial_load
 
 loop:
-    MOVQ    buf+0(FP), DI
-    VMOVDQU (DI)(AX*1), Y8          // load low 32-bytes
-    VMOVDQU 0x20(DI)(AX*1), Y9      // load high 32-bytes
-    ADDQ    $0x40, AX
+	MOVQ    buf+0(FP), DI
+	VMOVDQU (DI)(AX*1), Y8     // load low 32-bytes
+	VMOVDQU 0x20(DI)(AX*1), Y9 // load high 32-bytes
+	ADDQ    $0x40, AX
 
 loop_after_load:
-    PUSHQ CX
-    PUSHQ AX
+	PUSHQ CX
+	PUSHQ AX
 
-    MOVQ    p3+16(FP), DX
-    CALL ·__find_odd_backslash_sequences(SB)
+	MOVQ p3+16(FP), DX
+	CALL ·__find_odd_backslash_sequences(SB)
 
-    MOVQ AX, DX                  // odd_ends + 16
-    MOVQ prev_iter_inside_quote+24(FP), CX
-    MOVQ quote_bits+32(FP), R8
-    MOVQ error_mask+40(FP), R9
+	MOVQ AX, DX                            // odd_ends + 16
+	MOVQ prev_iter_inside_quote+24(FP), CX
+	MOVQ quote_bits+32(FP), R8
+	MOVQ error_mask+40(FP), R9
 
-    CALL ·__find_quote_mask_and_bits(SB)
-    PUSHQ AX                     //  MOVQ AX, quote_mask + 64
+	CALL  ·__find_quote_mask_and_bits(SB)
+	PUSHQ AX                              // MOVQ AX, quote_mask + 64
 
-    MOVQ whitespace+48(FP), DX
-    MOVQ structurals_in+56(FP), CX
+	MOVQ whitespace+48(FP), DX
+	MOVQ structurals_in+56(FP), CX
 
-    CALL ·__find_whitespace_and_structurals(SB)
+	CALL ·__find_whitespace_and_structurals(SB)
 
-    MOVQ structurals_in+56(FP), DI; MOVQ (DI), DI // DI = structurals
-    MOVQ whitespace+48(FP), SI; MOVQ (SI), SI     // SI = whitespace
-    POPQ DX                                       // DX = quote_mask
-    PUSHQ DX                                      // Save again for newline determination
+	MOVQ  structurals_in+56(FP), DI; MOVQ (DI), DI // DI = structurals
+	MOVQ  whitespace+48(FP), SI; MOVQ (SI), SI     // SI = whitespace
+	POPQ  DX                                       // DX = quote_mask
+	PUSHQ DX                                       // Save again for newline determination
 
-    MOVQ quote_bits+32(FP), CX; MOVQ (CX), CX     // CX = quote_bits
-    MOVQ prev_iter_ends_pseudo_pred+64(FP), R8    // R8 = &prev_iter_ends_pseudo_pred
+	MOVQ quote_bits+32(FP), CX; MOVQ (CX), CX  // CX = quote_bits
+	MOVQ prev_iter_ends_pseudo_pred+64(FP), R8 // R8 = &prev_iter_ends_pseudo_pred
 
-    CALL ·__finalize_structurals(SB)
+	CALL ·__finalize_structurals(SB)
 
-    POPQ DX                                       // DX = quote_mask
-    CMPQ ndjson+112(FP), $0
-    JZ   skip_ndjson_detection
-    CALL ·__find_newline_delimiters(SB)
-    ORQ  BX, AX
+	POPQ DX                             // DX = quote_mask
+	CMPQ ndjson+112(FP), $0
+	JZ   skip_ndjson_detection
+	CALL ·__find_newline_delimiters(SB)
+	ORQ  BX, AX
 
 skip_ndjson_detection:
-    MOVQ indexes+72(FP), DI
-    MOVQ index+80(FP), SI; MOVQ (SI), BX        // BX = index
-    MOVQ carried+96(FP), R11; MOVQ (R11), DX    // DX = carried
-    MOVQ position+104(FP), R12; MOVQ (R12), R10 // R10 = position
-    CALL ·__flatten_bits_incremental(SB)
-    MOVQ BX, (SI)                               // *index = BX
-    MOVQ DX, (R11)                              // *carried = DX
-    MOVQ R10, (R12)                             // *position = R10
+	MOVQ indexes+72(FP), DI
+	MOVQ index+80(FP), SI; MOVQ (SI), BX        // BX = index
+	MOVQ carried+96(FP), R11; MOVQ (R11), DX    // DX = carried
+	MOVQ position+104(FP), R12; MOVQ (R12), R10 // R10 = position
+	CALL ·__flatten_bits_incremental(SB)
+	MOVQ BX, (SI)                               // *index = BX
+	MOVQ DX, (R11)                              // *carried = DX
+	MOVQ R10, (R12)                             // *position = R10
 
-    POPQ AX
-    POPQ CX
+	POPQ AX
+	POPQ CX
 
-    CMPQ BX, indexes_len+88(FP)
-    JGE  done
+	CMPQ BX, indexes_len+88(FP)
+	JGE  done
 
-    CMPQ AX, CX
-    JLT  loop
+	CMPQ AX, CX
+	JLT  loop
 
-    // Check if AX is not aligned on a 64-byte boundary, this signals the last (partial) iteration
-    MOVQ AX, BX
-    ANDQ $0x3f, BX
-    CMPQ BX, $0
-    JNE  done
+	// Check if AX is not aligned on a 64-byte boundary, this signals the last (partial) iteration
+	MOVQ AX, BX
+	ANDQ $0x3f, BX
+	CMPQ BX, $0
+	JNE  done
 
 check_partial_load:
-    MOVQ len+8(FP), CX
-    ANDQ $0x3f, CX
-    CMPQ CX, $0
-    JNE  masking // end of message is not aligned on 64-byte boundary, so mask the remaining bytes
+	MOVQ len+8(FP), CX
+	ANDQ $0x3f, CX
+	CMPQ CX, $0
+	JNE  masking       // end of message is not aligned on 64-byte boundary, so mask the remaining bytes
 
 done:
-    MOVQ AX, processed+120(FP)
-    VZEROUPPER
-    RET
+	MOVQ AX, processed+120(FP)
+	VZEROUPPER
+	RET
 
 masking:
-    // Do a partial load and mask out bytes after the end of the message with whitespace
-    VPBROADCASTQ WHITESPACE<>(SB), Y13 // Load padding whitespace constant
+	// Do a partial load and mask out bytes after the end of the message with whitespace
+	VPBROADCASTQ WHITESPACE<>(SB), Y13 // Load padding whitespace constant
 
-    MOVQ    buf+0(FP), DI
-    VMOVDQU (DI)(AX*1), Y8  // Always load low 32-bytes
-    CMPQ CX, $0x20
-    JGE  masking_high
+	MOVQ    buf+0(FP), DI
+	VMOVDQU (DI)(AX*1), Y8 // Always load low 32-bytes
+	CMPQ    CX, $0x20
+	JGE     masking_high
 
-    // Perform masking on low 32-bytes
-    MASK_WHITESPACE(0x1f, Y8)
-    VMOVDQU Y13, Y9
-    JMP  masking_done
+	// Perform masking on low 32-bytes
+	MASK_WHITESPACE(0x1f, Y8)
+	VMOVDQU Y13, Y9
+	JMP     masking_done
 
 masking_high:
-    // Perform masking on high 32-bytes
-    VMOVDQU 0x20(DI)(AX*1), Y9 // Load high 32-bytes
-    MASK_WHITESPACE(0x3f, Y9)
+	// Perform masking on high 32-bytes
+	VMOVDQU 0x20(DI)(AX*1), Y9 // Load high 32-bytes
+	MASK_WHITESPACE(0x3f, Y9)
 
 masking_done:
-    ADDQ  CX, AX
-    JMP   loop_after_load // Rejoin loop after regular loading
-
+	ADDQ CX, AX
+	JMP  loop_after_load // Rejoin loop after regular loading
 
 DATA MASKTABLE<>+0x000(SB)/8, $0xffffffffffffffff
 DATA MASKTABLE<>+0x008(SB)/8, $0xffffffffffffffff

--- a/find_structural_bits_avx512_amd64.s
+++ b/find_structural_bits_avx512_amd64.s
@@ -4,166 +4,164 @@
 
 TEXT ·_find_structural_bits_avx512(SB), $0-56
 
-    CALL ·__init_odd_backslash_sequences_avx512(SB)
-    CALL ·__init_quote_mask_and_bits_avx512(SB)
-    CALL ·__init_whitespace_and_structurals_avx512(SB)
-    CALL ·__init_newline_delimiters_avx512(SB)
+	CALL ·__init_odd_backslash_sequences_avx512(SB)
+	CALL ·__init_quote_mask_and_bits_avx512(SB)
+	CALL ·__init_whitespace_and_structurals_avx512(SB)
+	CALL ·__init_newline_delimiters_avx512(SB)
 
-    MOVQ p1+0(FP), DI
-    MOVQ p3+8(FP), DX
+	MOVQ p1+0(FP), DI
+	MOVQ p3+8(FP), DX
 
-    KORQ K_ERRORMASK, K_ERRORMASK, K_ERRORMASK
+	KORQ K_ERRORMASK, K_ERRORMASK, K_ERRORMASK
 
-    VMOVDQU32 (DI), Z8
+	VMOVDQU32 (DI), Z8
 
-    CALL ·__find_odd_backslash_sequences_avx512(SB)
+	CALL ·__find_odd_backslash_sequences_avx512(SB)
 
-    MOVQ AX, DX                  // odd_ends + 16
-    MOVQ prev_iter_inside_quote+16(FP), CX
+	MOVQ AX, DX                            // odd_ends + 16
+	MOVQ prev_iter_inside_quote+16(FP), CX
 
-    CALL ·__find_quote_mask_and_bits_avx512(SB)
-    PUSHQ AX                     //  MOVQ AX, quote_mask + 64
+	CALL  ·__find_quote_mask_and_bits_avx512(SB)
+	PUSHQ AX                                     // MOVQ AX, quote_mask + 64
 
-    CALL ·__find_whitespace_and_structurals_avx512(SB)
+	CALL ·__find_whitespace_and_structurals_avx512(SB)
 
-    POPQ DX                                       // DX = quote_mask
-    MOVQ prev_iter_ends_pseudo_pred+40(FP), R8    // R8 = &prev_iter_ends_pseudo_pred
+	POPQ DX                                    // DX = quote_mask
+	MOVQ prev_iter_ends_pseudo_pred+40(FP), R8 // R8 = &prev_iter_ends_pseudo_pred
 
-    CALL ·__finalize_structurals_avx512(SB)
+	CALL ·__finalize_structurals_avx512(SB)
 
-    VZEROUPPER
-    MOVQ  error_mask+24(FP), R9
-    KMOVQ K_ERRORMASK, (R9)
-    MOVQ  AX, structurals+48(FP)
-    RET
+	VZEROUPPER
+	MOVQ  error_mask+24(FP), R9
+	KMOVQ K_ERRORMASK, (R9)
+	MOVQ  AX, structurals+48(FP)
+	RET
 
 #define MASK_WHITESPACE(MAX, Y) \
-    LEAQ MASKTABLE<>(SB), DX    \
-    MOVQ $MAX, BX               \
-    SUBQ CX, BX                 \
-    VMOVDQU  (DX)(BX*1), Y10    \ // Load mask
-    VPCMPEQB Y11, Y11, Y11      \ // Set all bits
-    VPXOR    Y11, Y10, Y12      \ // Invert mask
-    VPAND    Y13, Y12, Y12      \ // Mask whitespace
-    VPAND    Y10, Y,   Y        \ // Mask message
-    VPOR     Y12, Y,   Y          // Combine together
-
+	LEAQ     MASKTABLE<>(SB), DX \
+	MOVQ     $MAX, BX            \
+	SUBQ     CX, BX              \
+	VMOVDQU  (DX)(BX*1), Y10     \ // Load mask
+	VPCMPEQB Y11, Y11, Y11       \ // Set all bits
+	VPXOR    Y11, Y10, Y12       \ // Invert mask
+	VPAND    Y13, Y12, Y12       \ // Mask whitespace
+	VPAND    Y10, Y, Y           \ // Mask message
+	VPOR     Y12, Y, Y           // Combine together
 
 TEXT ·_find_structural_bits_in_slice_avx512(SB), $0-104
 
-    CALL ·__init_odd_backslash_sequences_avx512(SB)
-    CALL ·__init_quote_mask_and_bits_avx512(SB)
-    CALL ·__init_whitespace_and_structurals_avx512(SB)
-    CALL ·__init_newline_delimiters_avx512(SB)
+	CALL ·__init_odd_backslash_sequences_avx512(SB)
+	CALL ·__init_quote_mask_and_bits_avx512(SB)
+	CALL ·__init_whitespace_and_structurals_avx512(SB)
+	CALL ·__init_newline_delimiters_avx512(SB)
 
-    MOVQ  error_mask+32(FP), R9
-    KMOVQ (R9), K_ERRORMASK
+	MOVQ  error_mask+32(FP), R9
+	KMOVQ (R9), K_ERRORMASK
 
-    XORQ AX, AX
-    MOVQ len+8(FP), CX
-    ANDQ $0xffffffffffffffc0, CX
-    CMPQ  AX, CX
-    JEQ   check_partial_load
+	XORQ AX, AX
+	MOVQ len+8(FP), CX
+	ANDQ $0xffffffffffffffc0, CX
+	CMPQ AX, CX
+	JEQ  check_partial_load
 
 loop:
-    MOVQ    buf+0(FP), DI
-    VMOVDQU32 (DI)(AX*1), Z8
-    ADDQ    $0x40, AX
+	MOVQ      buf+0(FP), DI
+	VMOVDQU32 (DI)(AX*1), Z8
+	ADDQ      $0x40, AX
 
 loop_after_load:
-    PUSHQ CX
-    PUSHQ AX
+	PUSHQ CX
+	PUSHQ AX
 
-    MOVQ    p3+16(FP), DX
-    CALL ·__find_odd_backslash_sequences_avx512(SB)
+	MOVQ p3+16(FP), DX
+	CALL ·__find_odd_backslash_sequences_avx512(SB)
 
-    MOVQ AX, DX                  // odd_ends + 16
-    MOVQ prev_iter_inside_quote+24(FP), CX
+	MOVQ AX, DX                            // odd_ends + 16
+	MOVQ prev_iter_inside_quote+24(FP), CX
 
-    CALL ·__find_quote_mask_and_bits_avx512(SB)
-    PUSHQ AX                     //  MOVQ AX, quote_mask + 64
+	CALL  ·__find_quote_mask_and_bits_avx512(SB)
+	PUSHQ AX                                     // MOVQ AX, quote_mask + 64
 
-    CALL ·__find_whitespace_and_structurals_avx512(SB)
+	CALL ·__find_whitespace_and_structurals_avx512(SB)
 
-    POPQ DX                                       // DX = quote_mask
-    PUSHQ DX                                      // Save again for newline determination
-    MOVQ prev_iter_ends_pseudo_pred+40(FP), R8    // R8 = &prev_iter_ends_pseudo_pred
+	POPQ  DX                                    // DX = quote_mask
+	PUSHQ DX                                    // Save again for newline determination
+	MOVQ  prev_iter_ends_pseudo_pred+40(FP), R8 // R8 = &prev_iter_ends_pseudo_pred
 
-    CALL ·__finalize_structurals_avx512(SB)
+	CALL ·__finalize_structurals_avx512(SB)
 
-    POPQ DX                                       // DX = quote_mask
-    CMPQ ndjson+88(FP), $0
-    JZ   skip_ndjson_detection
-    CALL ·__find_newline_delimiters_avx512(SB)
-    ORQ  BX, AX
+	POPQ DX                                    // DX = quote_mask
+	CMPQ ndjson+88(FP), $0
+	JZ   skip_ndjson_detection
+	CALL ·__find_newline_delimiters_avx512(SB)
+	ORQ  BX, AX
 
 skip_ndjson_detection:
-    MOVQ indexes+48(FP), DI
-    MOVQ index+56(FP), SI; MOVQ (SI), BX        // BX = index
-    MOVQ carried+72(FP), R11; MOVQ (R11), DX    // DX = carried
-    MOVQ position+80(FP), R12; MOVQ (R12), R10 // R10 = position
-    CALL ·__flatten_bits_incremental(SB)
-    MOVQ BX, (SI)                               // *index = BX
-    MOVQ DX, (R11)                              // *carried = DX
-    MOVQ R10, (R12)                             // *position = R10
+	MOVQ indexes+48(FP), DI
+	MOVQ index+56(FP), SI; MOVQ (SI), BX       // BX = index
+	MOVQ carried+72(FP), R11; MOVQ (R11), DX   // DX = carried
+	MOVQ position+80(FP), R12; MOVQ (R12), R10 // R10 = position
+	CALL ·__flatten_bits_incremental(SB)
+	MOVQ BX, (SI)                              // *index = BX
+	MOVQ DX, (R11)                             // *carried = DX
+	MOVQ R10, (R12)                            // *position = R10
 
-    POPQ AX
-    POPQ CX
+	POPQ AX
+	POPQ CX
 
-    CMPQ BX, indexes_len+64(FP)
-    JGE  done
+	CMPQ BX, indexes_len+64(FP)
+	JGE  done
 
-    CMPQ AX, CX
-    JLT  loop
+	CMPQ AX, CX
+	JLT  loop
 
-    // Check if AX is not aligned on a 64-byte boundary, this signals the last (partial) iteration
-    MOVQ AX, BX
-    ANDQ $0x3f, BX
-    CMPQ BX, $0
-    JNE  done
+	// Check if AX is not aligned on a 64-byte boundary, this signals the last (partial) iteration
+	MOVQ AX, BX
+	ANDQ $0x3f, BX
+	CMPQ BX, $0
+	JNE  done
 
 check_partial_load:
-    MOVQ len+8(FP), CX
-    ANDQ $0x3f, CX
-    CMPQ CX, $0
-    JNE  masking // end of message is not aligned on 64-byte boundary, so mask the remaining bytes
+	MOVQ len+8(FP), CX
+	ANDQ $0x3f, CX
+	CMPQ CX, $0
+	JNE  masking       // end of message is not aligned on 64-byte boundary, so mask the remaining bytes
 
 done:
-    VZEROUPPER
-    MOVQ  error_mask+32(FP), R9
-    KMOVQ K_ERRORMASK, (R9)
-    MOVQ  AX, processed+96(FP)
-    RET
+	VZEROUPPER
+	MOVQ  error_mask+32(FP), R9
+	KMOVQ K_ERRORMASK, (R9)
+	MOVQ  AX, processed+96(FP)
+	RET
 
 masking:
-    // Do a partial load and mask out bytes after the end of the message with whitespace
-    VPBROADCASTQ WHITESPACE<>(SB), Y13 // Load padding whitespace constant
+	// Do a partial load and mask out bytes after the end of the message with whitespace
+	VPBROADCASTQ WHITESPACE<>(SB), Y13 // Load padding whitespace constant
 
-    MOVQ    buf+0(FP), DI
-    VMOVDQU (DI)(AX*1), Y8  // Always load low 32-bytes
-    CMPQ CX, $0x20
-    JGE  masking_high
+	MOVQ    buf+0(FP), DI
+	VMOVDQU (DI)(AX*1), Y8 // Always load low 32-bytes
+	CMPQ    CX, $0x20
+	JGE     masking_high
 
-    // Perform masking on low 32-bytes
-    MASK_WHITESPACE(0x1f, Y8)
-    VMOVDQU Y13, Y9
-    JMP  masking_done
+	// Perform masking on low 32-bytes
+	MASK_WHITESPACE(0x1f, Y8)
+	VMOVDQU Y13, Y9
+	JMP     masking_done
 
 masking_high:
-    // Perform masking on high 32-bytes
-    VMOVDQU 0x20(DI)(AX*1), Y9 // Load high 32-bytes
-    MASK_WHITESPACE(0x3f, Y9)
+	// Perform masking on high 32-bytes
+	VMOVDQU 0x20(DI)(AX*1), Y9 // Load high 32-bytes
+	MASK_WHITESPACE(0x3f, Y9)
 
 masking_done:
-    ADDQ  CX, AX
+	ADDQ CX, AX
 
-    // Merge Y9 into upper half of Z8
-    VPXORD    Z10, Z10, Z10
-    VALIGND   $8, Z10, Z9, Z9
-    VPORD     Z9, Z8, Z8
+	// Merge Y9 into upper half of Z8
+	VPXORD  Z10, Z10, Z10
+	VALIGND $8, Z10, Z9, Z9
+	VPORD   Z9, Z8, Z8
 
-    JMP   loop_after_load // Rejoin loop after regular loading
-
+	JMP loop_after_load // Rejoin loop after regular loading
 
 DATA MASKTABLE<>+0x000(SB)/8, $0xffffffffffffffff
 DATA MASKTABLE<>+0x008(SB)/8, $0xffffffffffffffff

--- a/find_whitespace_and_structurals_amd64.s
+++ b/find_whitespace_and_structurals_amd64.s
@@ -47,75 +47,74 @@ GLOBL LCDATA1<>(SB), 8, $320
 
 TEXT ·_find_whitespace_and_structurals(SB), $0-24
 
-    MOVQ input+0(FP), DI
-    MOVQ whitespace+8(FP), DX
-    MOVQ structurals+16(FP), CX
+	MOVQ input+0(FP), DI
+	MOVQ whitespace+8(FP), DX
+	MOVQ structurals+16(FP), CX
 
-    VMOVDQU    (DI), Y8          // load low 32-bytes
-    VMOVDQU    0x20(DI), Y9      // load high 32-bytes
+	VMOVDQU (DI), Y8     // load low 32-bytes
+	VMOVDQU 0x20(DI), Y9 // load high 32-bytes
 
-    CALL ·__find_whitespace_and_structurals(SB)
+	CALL ·__find_whitespace_and_structurals(SB)
 
-    VZEROUPPER
-    RET
-
+	VZEROUPPER
+	RET
 
 TEXT ·__find_whitespace_and_structurals(SB), $0
-    LEAQ LCDATA1<>(SB), BP
+	LEAQ LCDATA1<>(SB), BP
 
-    VMOVDQA   Y8, Y0             // vmovdqu    ymm0, yword [rdi]
-    VMOVDQA   Y9, Y1             // vmovdqu    ymm1, yword [rsi]
-    VMOVDQA   (BP), Y2           // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
-    VPSHUFB   Y0, Y2, Y3         // vpshufb    ymm3, ymm2, ymm0
-    VPSRLD    $4, Y0, Y0         // vpsrld    ymm0, ymm0, 4
-    VMOVDQA   0x40(BP), Y4       // vmovdqa    ymm4, yword 32[rbp] /* [rip + LCPI0_1] */
-    VPAND     Y4, Y0, Y0         // vpand    ymm0, ymm0, ymm4
-    VMOVDQA   0x80(BP), Y5       // vmovdqa    ymm5, yword 64[rbp] /* [rip + LCPI0_2] */
-    VPSHUFB   Y0, Y5, Y0         // vpshufb    ymm0, ymm5, ymm0
-    VPAND     Y3, Y0, Y0         // vpand    ymm0, ymm0, ymm3
-    VPSHUFB   Y1, Y2, Y2         // vpshufb    ymm2, ymm2, ymm1
-    VPSRLD    $4, Y1, Y1         // vpsrld    ymm1, ymm1, 4
-    VPAND     Y4, Y1, Y1         // vpand    ymm1, ymm1, ymm4
-    VPSHUFB   Y1, Y5, Y1         // vpshufb    ymm1, ymm5, ymm1
-    VPAND     Y2, Y1, Y1         // vpand    ymm1, ymm1, ymm2
-    VMOVDQA   0xc0(BP), Y2       // vmovdqa    ymm2, yword 96[rbp] /* [rip + LCPI0_3] */
-    VPAND     Y2, Y0, Y3         // vpand    ymm3, ymm0, ymm2
-    VPXOR     Y4, Y4, Y4         // vpxor    ymm4, ymm4, ymm4
-    VPCMPEQB  Y4, Y3, Y3         // vpcmpeqb    ymm3, ymm3, ymm4
-    VPAND     Y2, Y1, Y2         // vpand    ymm2, ymm1, ymm2
-    VPCMPEQB  Y4, Y2, Y2         // vpcmpeqb    ymm2, ymm2, ymm4
-    VPMOVMSKB Y3, AX             // vpmovmskb    eax, ymm3
-    VPMOVMSKB Y2, SI             // vpmovmskb    esi, ymm2
-    SHLQ      $32, SI            // shl    rsi, 32
-    ORQ       AX, SI             // or    rsi, rax
-    NOTQ      SI                 // not    rsi
-    MOVQ      SI, (CX)           // mov    qword [rcx], rsi
-    VMOVDQA   0x100(BP), Y2      // vmovdqa    ymm2, yword 128[rbp] /* [rip + LCPI0_4] */
-    VPAND     Y2, Y0, Y0         // vpand    ymm0, ymm0, ymm2
-    VPCMPEQB  Y4, Y0, Y0         // vpcmpeqb    ymm0, ymm0, ymm4
-    VPAND     Y2, Y1, Y1         // vpand    ymm1, ymm1, ymm2
-    VPCMPEQB  Y4, Y1, Y1         // vpcmpeqb    ymm1, ymm1, ymm4
-    VPMOVMSKB Y0, AX             // vpmovmskb    eax, ymm0
-    VPMOVMSKB Y1, CX             // vpmovmskb    ecx, ymm1
-    SHLQ      $32, CX            // shl    rcx, 32
-    ORQ       AX, CX             // or    rcx, rax
-    NOTQ      CX                 // not    rcx
-    MOVQ      CX, (DX)           // mov    qword [rdx], rcx
-    RET
+	VMOVDQA   Y8, Y0        // vmovdqu    ymm0, yword [rdi]
+	VMOVDQA   Y9, Y1        // vmovdqu    ymm1, yword [rsi]
+	VMOVDQA   (BP), Y2      // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
+	VPSHUFB   Y0, Y2, Y3    // vpshufb    ymm3, ymm2, ymm0
+	VPSRLD    $4, Y0, Y0    // vpsrld    ymm0, ymm0, 4
+	VMOVDQA   0x40(BP), Y4  // vmovdqa    ymm4, yword 32[rbp] /* [rip + LCPI0_1] */
+	VPAND     Y4, Y0, Y0    // vpand    ymm0, ymm0, ymm4
+	VMOVDQA   0x80(BP), Y5  // vmovdqa    ymm5, yword 64[rbp] /* [rip + LCPI0_2] */
+	VPSHUFB   Y0, Y5, Y0    // vpshufb    ymm0, ymm5, ymm0
+	VPAND     Y3, Y0, Y0    // vpand    ymm0, ymm0, ymm3
+	VPSHUFB   Y1, Y2, Y2    // vpshufb    ymm2, ymm2, ymm1
+	VPSRLD    $4, Y1, Y1    // vpsrld    ymm1, ymm1, 4
+	VPAND     Y4, Y1, Y1    // vpand    ymm1, ymm1, ymm4
+	VPSHUFB   Y1, Y5, Y1    // vpshufb    ymm1, ymm5, ymm1
+	VPAND     Y2, Y1, Y1    // vpand    ymm1, ymm1, ymm2
+	VMOVDQA   0xc0(BP), Y2  // vmovdqa    ymm2, yword 96[rbp] /* [rip + LCPI0_3] */
+	VPAND     Y2, Y0, Y3    // vpand    ymm3, ymm0, ymm2
+	VPXOR     Y4, Y4, Y4    // vpxor    ymm4, ymm4, ymm4
+	VPCMPEQB  Y4, Y3, Y3    // vpcmpeqb    ymm3, ymm3, ymm4
+	VPAND     Y2, Y1, Y2    // vpand    ymm2, ymm1, ymm2
+	VPCMPEQB  Y4, Y2, Y2    // vpcmpeqb    ymm2, ymm2, ymm4
+	VPMOVMSKB Y3, AX        // vpmovmskb    eax, ymm3
+	VPMOVMSKB Y2, SI        // vpmovmskb    esi, ymm2
+	SHLQ      $32, SI       // shl    rsi, 32
+	ORQ       AX, SI        // or    rsi, rax
+	NOTQ      SI            // not    rsi
+	MOVQ      SI, (CX)      // mov    qword [rcx], rsi
+	VMOVDQA   0x100(BP), Y2 // vmovdqa    ymm2, yword 128[rbp] /* [rip + LCPI0_4] */
+	VPAND     Y2, Y0, Y0    // vpand    ymm0, ymm0, ymm2
+	VPCMPEQB  Y4, Y0, Y0    // vpcmpeqb    ymm0, ymm0, ymm4
+	VPAND     Y2, Y1, Y1    // vpand    ymm1, ymm1, ymm2
+	VPCMPEQB  Y4, Y1, Y1    // vpcmpeqb    ymm1, ymm1, ymm4
+	VPMOVMSKB Y0, AX        // vpmovmskb    eax, ymm0
+	VPMOVMSKB Y1, CX        // vpmovmskb    ecx, ymm1
+	SHLQ      $32, CX       // shl    rcx, 32
+	ORQ       AX, CX        // or    rcx, rax
+	NOTQ      CX            // not    rcx
+	MOVQ      CX, (DX)      // mov    qword [rdx], rcx
+	RET
 
 TEXT ·_find_whitespace_and_structurals_avx512(SB), $0-24
 
-    MOVQ input+0(FP), DI
+	MOVQ input+0(FP), DI
 
-    VMOVDQU32    (DI), Z8
+	VMOVDQU32 (DI), Z8
 
-    CALL ·__init_whitespace_and_structurals_avx512(SB)
-    CALL ·__find_whitespace_and_structurals_avx512(SB)
+	CALL ·__init_whitespace_and_structurals_avx512(SB)
+	CALL ·__find_whitespace_and_structurals_avx512(SB)
 
-    VZEROUPPER
-    KMOVQ K_WHITESPACE, whitespace+8(FP)
-    KMOVQ K_STRUCTURALS, structurals+16(FP)
-    RET
+	VZEROUPPER
+	KMOVQ K_WHITESPACE, whitespace+8(FP)
+	KMOVQ K_STRUCTURALS, structurals+16(FP)
+	RET
 
 #define ZERO_CONST   Z20
 #define WSAS_CONST_1 Z21
@@ -125,25 +124,25 @@ TEXT ·_find_whitespace_and_structurals_avx512(SB), $0-24
 #define WSAS_CONST_5 Z25
 
 TEXT ·__init_whitespace_and_structurals_avx512(SB), $0
-    LEAQ        LCDATA1<>(SB), BP
-    VPXORD      ZERO_CONST, ZERO_CONST, ZERO_CONST
-    VMOVDQU32   0x000(BP), WSAS_CONST_1
-    VMOVDQU32   0x040(BP), WSAS_CONST_2
-    VMOVDQU32   0x080(BP), WSAS_CONST_3
-    VMOVDQU32   0x0c0(BP), WSAS_CONST_4
-    VMOVDQU32   0x100(BP), WSAS_CONST_5
-    RET
+	LEAQ      LCDATA1<>(SB), BP
+	VPXORD    ZERO_CONST, ZERO_CONST, ZERO_CONST
+	VMOVDQU32 0x000(BP), WSAS_CONST_1
+	VMOVDQU32 0x040(BP), WSAS_CONST_2
+	VMOVDQU32 0x080(BP), WSAS_CONST_3
+	VMOVDQU32 0x0c0(BP), WSAS_CONST_4
+	VMOVDQU32 0x100(BP), WSAS_CONST_5
+	RET
 
 TEXT ·__find_whitespace_and_structurals_avx512(SB), $0
-    VPSHUFB     Z8, WSAS_CONST_1, Z3
-    VPSRLD      $4, Z8, Z0
-    VPANDD      WSAS_CONST_2, Z0, Z0
-    VPSHUFB     Z0, WSAS_CONST_3, Z0
-    VPANDD      Z3, Z0, Z0
-    VPANDD      WSAS_CONST_4, Z0, Z3
-    VPCMPEQB    ZERO_CONST, Z3, K_STRUCTURALS
-    KNOTQ       K_STRUCTURALS, K_STRUCTURALS
-    VPANDD      WSAS_CONST_5, Z0, Z0
-    VPCMPEQB    ZERO_CONST, Z0, K_WHITESPACE
-    KNOTQ       K_WHITESPACE, K_WHITESPACE
-    RET
+	VPSHUFB  Z8, WSAS_CONST_1, Z3
+	VPSRLD   $4, Z8, Z0
+	VPANDD   WSAS_CONST_2, Z0, Z0
+	VPSHUFB  Z0, WSAS_CONST_3, Z0
+	VPANDD   Z3, Z0, Z0
+	VPANDD   WSAS_CONST_4, Z0, Z3
+	VPCMPEQB ZERO_CONST, Z3, K_STRUCTURALS
+	KNOTQ    K_STRUCTURALS, K_STRUCTURALS
+	VPANDD   WSAS_CONST_5, Z0, Z0
+	VPCMPEQB ZERO_CONST, Z0, K_WHITESPACE
+	KNOTQ    K_WHITESPACE, K_WHITESPACE
+	RET

--- a/flatten_bits_amd64.s
+++ b/flatten_bits_amd64.s
@@ -9,53 +9,52 @@
 
 TEXT ·_flatten_bits_incremental(SB), $0-40
 
-    MOVQ base_ptr+0(FP), DI
-    MOVQ pbase+8(FP), SI
-    MOVQ mask+16(FP), MASK
-    MOVQ carried+24(FP), R11
-    MOVQ position+32(FP), R12
-    MOVQ (SI), INDEX
-    MOVQ (R11), CARRIED
-    MOVQ (R12), POSITION
-    CALL ·__flatten_bits_incremental(SB)
-    MOVQ   POSITION, (R12)
-    MOVQ   CARRIED, (R11)
-    MOVQ   INDEX, (SI)
-    RET
-
+	MOVQ base_ptr+0(FP), DI
+	MOVQ pbase+8(FP), SI
+	MOVQ mask+16(FP), MASK
+	MOVQ carried+24(FP), R11
+	MOVQ position+32(FP), R12
+	MOVQ (SI), INDEX
+	MOVQ (R11), CARRIED
+	MOVQ (R12), POSITION
+	CALL ·__flatten_bits_incremental(SB)
+	MOVQ POSITION, (R12)
+	MOVQ CARRIED, (R11)
+	MOVQ INDEX, (SI)
+	RET
 
 TEXT ·__flatten_bits_incremental(SB), $0
-    XORQ SHIFTS, SHIFTS
+	XORQ SHIFTS, SHIFTS
 
-    // First iteration takes CARRIED into account
-    TZCNTQ MASK, ZEROS
-    JCS    done        // carry is set if ZEROS == 64
+	// First iteration takes CARRIED into account
+	TZCNTQ MASK, ZEROS
+	JCS    done        // carry is set if ZEROS == 64
 
-    // Two shifts required because maximum combined shift (63+1) exceeds 6-bits
-    SHRQ   $1, MASK
-    SHRQ   ZEROS, MASK
-    INCQ   ZEROS
-    ADDQ   ZEROS, SHIFTS
-    ADDQ   CARRIED, ZEROS
-    MOVL   ZEROS, (DI)(INDEX*4)
-    ADDQ   $1, INDEX
-    ADDQ   ZEROS, POSITION
-    XORQ   CARRIED, CARRIED // Reset CARRIED to 0 (since it has been used)
+	// Two shifts required because maximum combined shift (63+1) exceeds 6-bits
+	SHRQ $1, MASK
+	SHRQ ZEROS, MASK
+	INCQ ZEROS
+	ADDQ ZEROS, SHIFTS
+	ADDQ CARRIED, ZEROS
+	MOVL ZEROS, (DI)(INDEX*4)
+	ADDQ $1, INDEX
+	ADDQ ZEROS, POSITION
+	XORQ CARRIED, CARRIED     // Reset CARRIED to 0 (since it has been used)
 
 loop:
-    TZCNTQ MASK, ZEROS
-    JCS    done        // carry is set if ZEROS == 64
+	TZCNTQ MASK, ZEROS
+	JCS    done        // carry is set if ZEROS == 64
 
-    INCQ   ZEROS
-    SHRQ   ZEROS, MASK
-    ADDQ   ZEROS, SHIFTS
-    MOVL   ZEROS, (DI)(INDEX*4)
-    ADDQ   $1, INDEX
-    ADDQ   ZEROS, POSITION
-    JMP    loop
+	INCQ ZEROS
+	SHRQ ZEROS, MASK
+	ADDQ ZEROS, SHIFTS
+	MOVL ZEROS, (DI)(INDEX*4)
+	ADDQ $1, INDEX
+	ADDQ ZEROS, POSITION
+	JMP  loop
 
 done:
-    MOVQ   $64, R9
-    SUBQ   SHIFTS, R9
-    ADDQ   R9, CARRIED    // CARRIED += 64 - shifts (remaining empty bits to carry over to next call)
-    RET
+	MOVQ $64, R9
+	SUBQ SHIFTS, R9
+	ADDQ R9, CARRIED // CARRIED += 64 - shifts (remaining empty bits to carry over to next call)
+	RET

--- a/parse_number_amd64.s
+++ b/parse_number_amd64.s
@@ -785,184 +785,208 @@ GLOBL LCTABLE<>(SB), 8, $6216
 
 TEXT ·_parse_number(SB), $0-56
 
-    MOVQ buf+0(FP), DI
-    MOVQ offset+8(FP), SI
-    MOVQ found_minus+16(FP), DX
-    MOVQ is_double+24(FP), CX
-    MOVQ resultDouble+32(FP), R8
-    MOVQ resultInt64+40(FP), R9
-    LEAQ LCTABLE<>(SB), BP
+	MOVQ buf+0(FP), DI
+	MOVQ offset+8(FP), SI
+	MOVQ found_minus+16(FP), DX
+	MOVQ is_double+24(FP), CX
+	MOVQ resultDouble+32(FP), R8
+	MOVQ resultInt64+40(FP), R9
+	LEAQ LCTABLE<>(SB), BP
 
-    WORD $0xf389                 // mov    ebx, esi
-    WORD $0x0148; BYTE $0xfb     // add    rbx, rdi
-    WORD $0xd284                 // test    dl, dl
-	JE LBB0_12
-    WORD $0x438a; BYTE $0x01     // mov    al, byte [rbx + 1]
-    WORD $0xc289                 // mov    edx, eax
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x0a     // cmp    dl, 10
-	JAE LBB0_19
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
-    WORD $0xb641; BYTE $0x01     // mov    r14b, 1
-    WORD $0x303c                 // cmp    al, 48
-	JE LBB0_13
+	WORD $0xf389             // mov    ebx, esi
+	WORD $0x0148; BYTE $0xfb // add    rbx, rdi
+	WORD $0xd284             // test    dl, dl
+	JE   LBB0_12
+	WORD $0x438a; BYTE $0x01 // mov    al, byte [rbx + 1]
+	WORD $0xc289             // mov    edx, eax
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x0a // cmp    dl, 10
+	JAE  LBB0_19
+	WORD $0xff48; BYTE $0xc3 // inc    rbx
+	WORD $0xb641; BYTE $0x01 // mov    r14b, 1
+	WORD $0x303c             // cmp    al, 48
+	JE   LBB0_13
+
 LBB0_3:
-    WORD $0xd004                 // add    al, -48
-    WORD $0x093c                 // cmp    al, 9
-	JA LBB0_19
-    WORD $0xb60f; BYTE $0xc0     // movzx    eax, al
-    LONG $0x017b8a40             // mov    dil, byte [rbx + 1]
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
-    WORD $0xfa89                 // mov    edx, edi
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x09     // cmp    dl, 9
-	JA LBB0_6
+	WORD $0xd004             // add    al, -48
+	WORD $0x093c             // cmp    al, 9
+	JA   LBB0_19
+	WORD $0xb60f; BYTE $0xc0 // movzx    eax, al
+	LONG $0x017b8a40         // mov    dil, byte [rbx + 1]
+	WORD $0xff48; BYTE $0xc3 // inc    rbx
+	WORD $0xfa89             // mov    edx, edi
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x09 // cmp    dl, 9
+	JA   LBB0_6
+
 LBB0_5:
-    LONG $0x80048d48             // lea    rax, [rax + 4*rax]
-    WORD $0xb60f; BYTE $0xd2     // movzx    edx, dl
-    LONG $0x42048d48             // lea    rax, [rdx + 2*rax]
-    LONG $0x017b8a40             // mov    dil, byte [rbx + 1]
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
-    WORD $0xfa89                 // mov    edx, edi
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x0a     // cmp    dl, 10
-	JB LBB0_5
+	LONG $0x80048d48         // lea    rax, [rax + 4*rax]
+	WORD $0xb60f; BYTE $0xd2 // movzx    edx, dl
+	LONG $0x42048d48         // lea    rax, [rdx + 2*rax]
+	LONG $0x017b8a40         // mov    dil, byte [rbx + 1]
+	WORD $0xff48; BYTE $0xc3 // inc    rbx
+	WORD $0xfa89             // mov    edx, edi
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x0a // cmp    dl, 10
+	JB   LBB0_5
+
 LBB0_6:
-    LONG $0x2eff8040             // cmp    dil, 46
-	JNE LBB0_15
+	LONG $0x2eff8040 // cmp    dil, 46
+	JNE  LBB0_15
+
 LBB0_7:
-    WORD $0x538a; BYTE $0x01     // mov    dl, byte [rbx + 1]
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x09     // cmp    dl, 9
-	JA LBB0_19
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
-    WORD $0x8948; BYTE $0xde     // mov    rsi, rbx
+	WORD $0x538a; BYTE $0x01 // mov    dl, byte [rbx + 1]
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x09 // cmp    dl, 9
+	JA   LBB0_19
+	WORD $0xff48; BYTE $0xc3 // inc    rbx
+	WORD $0x8948; BYTE $0xde // mov    rsi, rbx
+
 LBB0_9:
-    LONG $0x80048d48             // lea    rax, [rax + 4*rax]
-    WORD $0xb60f; BYTE $0xd2     // movzx    edx, dl
-    LONG $0x42048d48             // lea    rax, [rdx + 2*rax]
-    LONG $0x017e8a40             // mov    dil, byte [rsi + 1]
-    WORD $0xff48; BYTE $0xc6     // inc    rsi
-    WORD $0xfa89                 // mov    edx, edi
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x0a     // cmp    dl, 10
-	JB LBB0_9
-    WORD $0x2948; BYTE $0xf3     // sub    rbx, rsi
-    WORD $0x8949; BYTE $0xdb     // mov    r11, rbx
-    WORD $0x8948; BYTE $0xf3     // mov    rbx, rsi
-    LONG $0x20cf8040             // or    dil, 32
-    LONG $0x65ff8040             // cmp    dil, 101
-	JE LBB0_16
+	LONG $0x80048d48         // lea    rax, [rax + 4*rax]
+	WORD $0xb60f; BYTE $0xd2 // movzx    edx, dl
+	LONG $0x42048d48         // lea    rax, [rdx + 2*rax]
+	LONG $0x017e8a40         // mov    dil, byte [rsi + 1]
+	WORD $0xff48; BYTE $0xc6 // inc    rsi
+	WORD $0xfa89             // mov    edx, edi
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x0a // cmp    dl, 10
+	JB   LBB0_9
+	WORD $0x2948; BYTE $0xf3 // sub    rbx, rsi
+	WORD $0x8949; BYTE $0xdb // mov    r11, rbx
+	WORD $0x8948; BYTE $0xf3 // mov    rbx, rsi
+	LONG $0x20cf8040         // or    dil, 32
+	LONG $0x65ff8040         // cmp    dil, 101
+	JE   LBB0_16
+
 LBB0_11:
-    WORD $0xff31                 // xor    edi, edi
-	JMP LBB0_35
+	WORD $0xff31 // xor    edi, edi
+	JMP  LBB0_35
+
 LBB0_12:
-    WORD $0x038a                 // mov    al, byte [rbx]
-    WORD $0x3145; BYTE $0xf6     // xor    r14d, r14d
-    WORD $0x303c                 // cmp    al, 48
-	JNE LBB0_3
+	WORD $0x038a             // mov    al, byte [rbx]
+	WORD $0x3145; BYTE $0xf6 // xor    r14d, r14d
+	WORD $0x303c             // cmp    al, 48
+	JNE  LBB0_3
+
 LBB0_13:
-    LONG $0x017bb60f             // movzx    edi, byte [rbx + 1]
-    LONG $0x48958d48; WORD $0x0017; BYTE $0x00 // lea    rdx, 5960[rbp] /* [rip + __ZL55structural_or_whitespace_or_exponent_or_decimal_negated] */
-    WORD $0xc031                 // xor    eax, eax
-    LONG $0x00173c80             // cmp    byte [rdi + rdx], 0
-	JNE LBB0_43
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
-    LONG $0x2eff8040             // cmp    dil, 46
-	JE LBB0_7
+	LONG $0x017bb60f                           // movzx    edi, byte [rbx + 1]
+	LONG $0x48958d48; WORD $0x0017; BYTE $0x00 // lea    rdx, 5960[rbp] /* [rip + __ZL55structural_or_whitespace_or_exponent_or_decimal_negated] */
+	WORD $0xc031                               // xor    eax, eax
+	LONG $0x00173c80                           // cmp    byte [rdi + rdx], 0
+	JNE  LBB0_43
+	WORD $0xff48; BYTE $0xc3                   // inc    rbx
+	LONG $0x2eff8040                           // cmp    dil, 46
+	JE   LBB0_7
+
 LBB0_15:
-    WORD $0x3145; BYTE $0xdb     // xor    r11d, r11d
-    LONG $0x20cf8040             // or    dil, 32
-    LONG $0x65ff8040             // cmp    dil, 101
-	JNE LBB0_11
+	WORD $0x3145; BYTE $0xdb // xor    r11d, r11d
+	LONG $0x20cf8040         // or    dil, 32
+	LONG $0x65ff8040         // cmp    dil, 101
+	JNE  LBB0_11
+
 LBB0_16:
-    WORD $0x538a; BYTE $0x01     // mov    dl, byte [rbx + 1]
-    WORD $0xfa80; BYTE $0x2b     // cmp    dl, 43
-	JE LBB0_22
-    WORD $0xfa80; BYTE $0x2d     // cmp    dl, 45
-	JNE LBB0_23
-    LONG $0x02c38348             // add    rbx, 2
-    WORD $0xb241; BYTE $0x01     // mov    r10b, 1
-	JMP LBB0_25
+	WORD $0x538a; BYTE $0x01 // mov    dl, byte [rbx + 1]
+	WORD $0xfa80; BYTE $0x2b // cmp    dl, 43
+	JE   LBB0_22
+	WORD $0xfa80; BYTE $0x2d // cmp    dl, 45
+	JNE  LBB0_23
+	LONG $0x02c38348         // add    rbx, 2
+	WORD $0xb241; BYTE $0x01 // mov    r10b, 1
+	JMP  LBB0_25
+
 LBB0_22:
-    LONG $0x02c38348             // add    rbx, 2
-	JMP LBB0_24
+	LONG $0x02c38348 // add    rbx, 2
+	JMP  LBB0_24
+
 LBB0_23:
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
+	WORD $0xff48; BYTE $0xc3 // inc    rbx
+
 LBB0_24:
-    WORD $0x3145; BYTE $0xd2     // xor    r10d, r10d
+	WORD $0x3145; BYTE $0xd2 // xor    r10d, r10d
+
 LBB0_25:
-    WORD $0x138a                 // mov    dl, byte [rbx]
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x09     // cmp    dl, 9
-	JA LBB0_19
-    WORD $0xb60f; BYTE $0xfa     // movzx    edi, dl
-    LONG $0x01738a40             // mov    sil, byte [rbx + 1]
-    WORD $0xf289                 // mov    edx, esi
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x09     // cmp    dl, 9
-	JA LBB0_29
-    LONG $0xbf348d48             // lea    rsi, [rdi + 4*rdi]
-    WORD $0xb60f; BYTE $0xd2     // movzx    edx, dl
-    LONG $0x723c8d48             // lea    rdi, [rdx + 2*rsi]
-    LONG $0x02738a40             // mov    sil, byte [rbx + 2]
-    LONG $0x02c38348             // add    rbx, 2
-	JMP LBB0_30
+	WORD $0x138a             // mov    dl, byte [rbx]
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x09 // cmp    dl, 9
+	JA   LBB0_19
+	WORD $0xb60f; BYTE $0xfa // movzx    edi, dl
+	LONG $0x01738a40         // mov    sil, byte [rbx + 1]
+	WORD $0xf289             // mov    edx, esi
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x09 // cmp    dl, 9
+	JA   LBB0_29
+	LONG $0xbf348d48         // lea    rsi, [rdi + 4*rdi]
+	WORD $0xb60f; BYTE $0xd2 // movzx    edx, dl
+	LONG $0x723c8d48         // lea    rdi, [rdx + 2*rsi]
+	LONG $0x02738a40         // mov    sil, byte [rbx + 2]
+	LONG $0x02c38348         // add    rbx, 2
+	JMP  LBB0_30
+
 LBB0_29:
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
+	WORD $0xff48; BYTE $0xc3 // inc    rbx
+
 LBB0_30:
-    WORD $0xf289                 // mov    edx, esi
-    WORD $0xc280; BYTE $0xd0     // add    dl, -48
-    WORD $0xfa80; BYTE $0x09     // cmp    dl, 9
-	JA LBB0_32
-    LONG $0xbf348d48             // lea    rsi, [rdi + 4*rdi]
-    WORD $0xb60f; BYTE $0xd2     // movzx    edx, dl
-    LONG $0x723c8d48             // lea    rdi, [rdx + 2*rsi]
-    LONG $0x01738a40             // mov    sil, byte [rbx + 1]
-    WORD $0xff48; BYTE $0xc3     // inc    rbx
+	WORD $0xf289             // mov    edx, esi
+	WORD $0xc280; BYTE $0xd0 // add    dl, -48
+	WORD $0xfa80; BYTE $0x09 // cmp    dl, 9
+	JA   LBB0_32
+	LONG $0xbf348d48         // lea    rsi, [rdi + 4*rdi]
+	WORD $0xb60f; BYTE $0xd2 // movzx    edx, dl
+	LONG $0x723c8d48         // lea    rdi, [rdx + 2*rsi]
+	LONG $0x01738a40         // mov    sil, byte [rbx + 1]
+	WORD $0xff48; BYTE $0xc3 // inc    rbx
+
 LBB0_32:
-    LONG $0xd0c68040             // add    sil, -48
-    LONG $0x0afe8040             // cmp    sil, 10
-	JB LBB0_19
-    WORD $0x8948; BYTE $0xfa     // mov    rdx, rdi
-    WORD $0xf748; BYTE $0xda     // neg    rdx
-    WORD $0x8445; BYTE $0xd2     // test    r10b, r10b
-    LONG $0xd7440f48             // cmove    rdx, rdi
-    WORD $0x0149; BYTE $0xd3     // add    r11, rdx
+	LONG $0xd0c68040         // add    sil, -48
+	LONG $0x0afe8040         // cmp    sil, 10
+	JB   LBB0_19
+	WORD $0x8948; BYTE $0xfa // mov    rdx, rdi
+	WORD $0xf748; BYTE $0xda // neg    rdx
+	WORD $0x8445; BYTE $0xd2 // test    r10b, r10b
+	LONG $0xd7440f48         // cmove    rdx, rdi
+	WORD $0x0149; BYTE $0xd3 // add    r11, rdx
+
 LBB0_35:
-    WORD $0x8948; BYTE $0xc2     // mov    rdx, rax
-    WORD $0xf748; BYTE $0xda     // neg    rdx
-    WORD $0x8445; BYTE $0xf6     // test    r14b, r14b
-    LONG $0xd0440f48             // cmove    rdx, rax
-    WORD $0x094c; BYTE $0xdf     // or    rdi, r11
-	JE LBB0_39
-    WORD $0x8548; BYTE $0xd2     // test    rdx, rdx
-	JE LBB0_40
-    LONG $0x34838d49; WORD $0x0001; BYTE $0x00 // lea    rax, [r11 + 308]
-    LONG $0x02683d48; WORD $0x0000 // cmp    rax, 616
-	JBE LBB0_41
+	WORD $0x8948; BYTE $0xc2                   // mov    rdx, rax
+	WORD $0xf748; BYTE $0xda                   // neg    rdx
+	WORD $0x8445; BYTE $0xf6                   // test    r14b, r14b
+	LONG $0xd0440f48                           // cmove    rdx, rax
+	WORD $0x094c; BYTE $0xdf                   // or    rdi, r11
+	JE   LBB0_39
+	WORD $0x8548; BYTE $0xd2                   // test    rdx, rdx
+	JE   LBB0_40
+	LONG $0x34838d49; WORD $0x0001; BYTE $0x00 // lea    rax, [r11 + 308]
+	LONG $0x02683d48; WORD $0x0000             // cmp    rax, 616
+	JBE  LBB0_41
+
 LBB0_19:
-    WORD $0xc031                 // xor    eax, eax
+	WORD $0xc031 // xor    eax, eax
+
 LBB0_43:
-    MOVQ AX, success+48(FP)
-    RET
+	MOVQ AX, success+48(FP)
+	RET
+
 LBB0_39:
-    WORD $0x01c6; BYTE $0x00     // mov    byte [rcx], 0
-    WORD $0x8949; BYTE $0x11     // mov    qword [r9], rdx
-	JMP LBB0_42
+	WORD $0x01c6; BYTE $0x00 // mov    byte [rcx], 0
+	WORD $0x8949; BYTE $0x11 // mov    qword [r9], rdx
+	JMP  LBB0_42
+
 LBB0_40:
-    WORD $0x01c6; BYTE $0x01     // mov    byte [rcx], 1
-    LONG $0x0000c749; WORD $0x0000; BYTE $0x00 // mov    qword [r8], 0
-	JMP LBB0_42
+	WORD $0x01c6; BYTE $0x01                   // mov    byte [rcx], 1
+	LONG $0x0000c749; WORD $0x0000; BYTE $0x00 // mov    qword [r8], 0
+	JMP  LBB0_42
+
 LBB0_41:
-    LONG $0x2afbe1c4; BYTE $0xc2 // vcvtsi2sd    xmm0, xmm0, rdx
-    LONG $0x00458d48             // lea    rax, 0[rbp] /* [rip + __ZL12power_of_ten] */
-    QUAD $0x09a0d884597ba1c4; WORD $0x0000 // vmulsd    xmm0, xmm0, qword [rax + 8*r11 + 2464]
-    WORD $0x01c6; BYTE $0x01     // mov    byte [rcx], 1
-    LONG $0x117bc1c4; BYTE $0x00 // vmovsd    qword [r8], xmm0
+	LONG $0x2afbe1c4; BYTE $0xc2           // vcvtsi2sd    xmm0, xmm0, rdx
+	LONG $0x00458d48                       // lea    rax, 0[rbp] /* [rip + __ZL12power_of_ten] */
+	QUAD $0x09a0d884597ba1c4; WORD $0x0000 // vmulsd    xmm0, xmm0, qword [rax + 8*r11 + 2464]
+	WORD $0x01c6; BYTE $0x01               // mov    byte [rcx], 1
+	LONG $0x117bc1c4; BYTE $0x00           // vmovsd    qword [r8], xmm0
+
 LBB0_42:
-    WORD $0xb60f; BYTE $0x03     // movzx    eax, byte [rbx]
-    LONG $0x488d8d48; WORD $0x0013; BYTE $0x00 // lea    rcx, 4936[rbp] /* [rip + __ZL24structural_or_whitespace] */
-    LONG $0x00813c83             // cmp    dword [rcx + 4*rax], 0
-    WORD $0x950f; BYTE $0xd0     // setne    al
-	JMP LBB0_43
+	WORD $0xb60f; BYTE $0x03                   // movzx    eax, byte [rbx]
+	LONG $0x488d8d48; WORD $0x0013; BYTE $0x00 // lea    rcx, 4936[rbp] /* [rip + __ZL24structural_or_whitespace] */
+	LONG $0x00813c83                           // cmp    dword [rcx + 4*rax], 0
+	WORD $0x950f; BYTE $0xd0                   // setne    al
+	JMP  LBB0_43

--- a/parse_string_amd64.s
+++ b/parse_string_amd64.s
@@ -71,378 +71,409 @@ GLOBL LCDATA1<>(SB), 8, $576
 
 TEXT ·_parse_string_validate_only(SB), $0-40
 
-    MOVQ src+0(FP), DI
-    MOVQ maxStringSize+8(FP), SI
-    MOVQ str_length+16(FP), DX
-    MOVQ dst_length+24(FP), CX
-    LEAQ LCDATA1<>(SB), BP
+	MOVQ src+0(FP), DI
+	MOVQ maxStringSize+8(FP), SI
+	MOVQ str_length+16(FP), DX
+	MOVQ dst_length+24(FP), CX
+	LEAQ LCDATA1<>(SB), BP
 
-    WORD $0x8b4c; BYTE $0x1e     // mov    r11, qword [rsi]
-    WORD $0x854d; BYTE $0xdb     // test    r11, r11
-	JE LBB0_30
-    WORD $0xf631                 // xor    esi, esi
-    LONG $0x456ffdc5; BYTE $0x00 // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
-    LONG $0x4d6ffdc5; BYTE $0x20 // vmovdqa    ymm1, yword 32[rbp] /* [rip + LCPI0_1] */
-    LONG $0x404d8d4c             // lea    r9, 64[rbp] /* [rip + __ZL10digittoval] */
-    LONG $0x40958d4c; WORD $0x0001; BYTE $0x00 // lea    r10, 320[rbp] /* [rip + __ZL10escape_map] */
-    WORD $0x8949; BYTE $0xfd     // mov    r13, rdi
-    WORD $0x3145; BYTE $0xf6     // xor    r14d, r14d
-    WORD $0x8948; BYTE $0xf8     // mov    rax, rdi
+	WORD $0x8b4c; BYTE $0x1e                   // mov    r11, qword [rsi]
+	WORD $0x854d; BYTE $0xdb                   // test    r11, r11
+	JE   LBB0_30
+	WORD $0xf631                               // xor    esi, esi
+	LONG $0x456ffdc5; BYTE $0x00               // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
+	LONG $0x4d6ffdc5; BYTE $0x20               // vmovdqa    ymm1, yword 32[rbp] /* [rip + LCPI0_1] */
+	LONG $0x404d8d4c                           // lea    r9, 64[rbp] /* [rip + __ZL10digittoval] */
+	LONG $0x40958d4c; WORD $0x0001; BYTE $0x00 // lea    r10, 320[rbp] /* [rip + __ZL10escape_map] */
+	WORD $0x8949; BYTE $0xfd                   // mov    r13, rdi
+	WORD $0x3145; BYTE $0xf6                   // xor    r14d, r14d
+	WORD $0x8948; BYTE $0xf8                   // mov    rax, rdi
+
 LBB0_2:
-    LONG $0x106ffec5             // vmovdqu    ymm2, yword [rax]
-    LONG $0xd874edc5             // vpcmpeqb    ymm3, ymm2, ymm0
-    LONG $0xdbd7fdc5             // vpmovmskb    ebx, ymm3
-    LONG $0xd174edc5             // vpcmpeqb    ymm2, ymm2, ymm1
-    LONG $0xe2d77dc5             // vpmovmskb    r12d, ymm2
-    WORD $0x438d; BYTE $0xff     // lea    eax, [rbx - 1]
-    WORD $0x8544; BYTE $0xe0     // test    eax, r12d
-	JNE LBB0_3
-    LONG $0x24448d41; BYTE $0xff // lea    eax, [r12 - 1]
-    WORD $0xd885                 // test    eax, ebx
-	JE LBB0_28
-    WORD $0xd889                 // mov    eax, ebx
-    LONG $0xbc0f4cf3; BYTE $0xf8 // tzcnt    r15, rax
-    LONG $0x74b60f43; WORD $0x013d // movzx    esi, byte [r13 + r15 + 1]
-    LONG $0x75fe8348             // cmp    rsi, 117
-	JNE LBB0_26
-    WORD $0x8545; BYTE $0xe4     // test    r12d, r12d
-	JE LBB0_8
-    WORD $0x8944; BYTE $0xe0     // mov    eax, r12d
-    LONG $0xbc0f48f3; BYTE $0xf0 // tzcnt    rsi, rax
-    WORD $0x2944; BYTE $0xfe     // sub    esi, r15d
-    WORD $0xfe83; BYTE $0x06     // cmp    esi, 6
-	JAE LBB0_11
-	JMP LBB0_30
+	LONG $0x106ffec5               // vmovdqu    ymm2, yword [rax]
+	LONG $0xd874edc5               // vpcmpeqb    ymm3, ymm2, ymm0
+	LONG $0xdbd7fdc5               // vpmovmskb    ebx, ymm3
+	LONG $0xd174edc5               // vpcmpeqb    ymm2, ymm2, ymm1
+	LONG $0xe2d77dc5               // vpmovmskb    r12d, ymm2
+	WORD $0x438d; BYTE $0xff       // lea    eax, [rbx - 1]
+	WORD $0x8544; BYTE $0xe0       // test    eax, r12d
+	JNE  LBB0_3
+	LONG $0x24448d41; BYTE $0xff   // lea    eax, [r12 - 1]
+	WORD $0xd885                   // test    eax, ebx
+	JE   LBB0_28
+	WORD $0xd889                   // mov    eax, ebx
+	LONG $0xbc0f4cf3; BYTE $0xf8   // tzcnt    r15, rax
+	LONG $0x74b60f43; WORD $0x013d // movzx    esi, byte [r13 + r15 + 1]
+	LONG $0x75fe8348               // cmp    rsi, 117
+	JNE  LBB0_26
+	WORD $0x8545; BYTE $0xe4       // test    r12d, r12d
+	JE   LBB0_8
+	WORD $0x8944; BYTE $0xe0       // mov    eax, r12d
+	LONG $0xbc0f48f3; BYTE $0xf0   // tzcnt    rsi, rax
+	WORD $0x2944; BYTE $0xfe       // sub    esi, r15d
+	WORD $0xfe83; BYTE $0x06       // cmp    esi, 6
+	JAE  LBB0_11
+	JMP  LBB0_30
+
 LBB0_28:
-    LONG $0x20c58349             // add    r13, 32
-    LONG $0x20c68349             // add    r14, 32
-    WORD $0x894c; BYTE $0xe8     // mov    rax, r13
-	JMP LBB0_29
+	LONG $0x20c58349         // add    r13, 32
+	LONG $0x20c68349         // add    r14, 32
+	WORD $0x894c; BYTE $0xe8 // mov    rax, r13
+	JMP  LBB0_29
+
 LBB0_26:
-    LONG $0x163c8042; BYTE $0x00 // cmp    byte [rsi + r10], 0
-	JE LBB0_30
-    LONG $0x3d448d4b; BYTE $0x02 // lea    rax, [r13 + r15 + 2]
-    WORD $0xff49; BYTE $0xc7     // inc    r15
-    WORD $0x014d; BYTE $0xfe     // add    r14, r15
-	JMP LBB0_29
+	LONG $0x163c8042; BYTE $0x00 // cmp    byte [rsi + r10], 0
+	JE   LBB0_30
+	LONG $0x3d448d4b; BYTE $0x02 // lea    rax, [r13 + r15 + 2]
+	WORD $0xff49; BYTE $0xc7     // inc    r15
+	WORD $0x014d; BYTE $0xfe     // add    r14, r15
+	JMP  LBB0_29
+
 LBB0_8:
-    LONG $0x000020be; BYTE $0x00 // mov    esi, 32
-    LONG $0x15ff8341             // cmp    r15d, 21
-	JB LBB0_10
-    LONG $0xec478d41             // lea    eax, [r15 - 20]
-    LONG $0x7475c1c4; WORD $0x0554; BYTE $0x00 // vpcmpeqb    ymm2, ymm1, yword [r13 + rax]
-    LONG $0xc2d7fdc5             // vpmovmskb    eax, ymm2
-    LONG $0xbc0f48f3; BYTE $0xf0 // tzcnt    rsi, rax
-    WORD $0xc085                 // test    eax, eax
-    LONG $0x000020b8; BYTE $0x00 // mov    eax, 32
-    WORD $0x440f; BYTE $0xf0     // cmove    esi, eax
-    LONG $0x3e748d42; BYTE $0xec // lea    esi, [rsi + r15 - 20]
+	LONG $0x000020be; BYTE $0x00               // mov    esi, 32
+	LONG $0x15ff8341                           // cmp    r15d, 21
+	JB   LBB0_10
+	LONG $0xec478d41                           // lea    eax, [r15 - 20]
+	LONG $0x7475c1c4; WORD $0x0554; BYTE $0x00 // vpcmpeqb    ymm2, ymm1, yword [r13 + rax]
+	LONG $0xc2d7fdc5                           // vpmovmskb    eax, ymm2
+	LONG $0xbc0f48f3; BYTE $0xf0               // tzcnt    rsi, rax
+	WORD $0xc085                               // test    eax, eax
+	LONG $0x000020b8; BYTE $0x00               // mov    eax, 32
+	WORD $0x440f; BYTE $0xf0                   // cmove    esi, eax
+	LONG $0x3e748d42; BYTE $0xec               // lea    esi, [rsi + r15 - 20]
+
 LBB0_10:
-    WORD $0x2944; BYTE $0xfe     // sub    esi, r15d
-    WORD $0xfe83; BYTE $0x06     // cmp    esi, 6
-	JB LBB0_30
+	WORD $0x2944; BYTE $0xfe // sub    esi, r15d
+	WORD $0xfe83; BYTE $0x06 // cmp    esi, 6
+	JB   LBB0_30
+
 LBB0_11:
-    WORD $0x014d; BYTE $0xfd     // add    r13, r15
-    LONG $0x45b60f41; BYTE $0x02 // movzx    eax, byte [r13 + 2]
-    LONG $0x04be0f46; BYTE $0x08 // movsx    r8d, byte [rax + r9]
-    LONG $0x5db60f41; BYTE $0x03 // movzx    ebx, byte [r13 + 3]
-    LONG $0x1cbe0f42; BYTE $0x0b // movsx    ebx, byte [rbx + r9]
-    LONG $0x45b60f41; BYTE $0x04 // movzx    eax, byte [r13 + 4]
-    LONG $0x24be0f46; BYTE $0x08 // movsx    r12d, byte [rax + r9]
-    LONG $0x45b60f41; BYTE $0x05 // movzx    eax, byte [r13 + 5]
-    LONG $0x04be0f42; BYTE $0x08 // movsx    eax, byte [rax + r9]
-    LONG $0x0ce0c141             // shl    r8d, 12
-    WORD $0xe3c1; BYTE $0x08     // shl    ebx, 8
-    WORD $0x0944; BYTE $0xc3     // or    ebx, r8d
-    LONG $0x04e4c141             // shl    r12d, 4
-    WORD $0x0941; BYTE $0xc4     // or    r12d, eax
-    WORD $0x0941; BYTE $0xdc     // or    r12d, ebx
-    LONG $0x06458d49             // lea    rax, [r13 + 6]
-    WORD $0x8944; BYTE $0xe3     // mov    ebx, r12d
-    LONG $0xfc00e381; WORD $0xffff // and    ebx, -1024
-    LONG $0xd800fb81; WORD $0x0000 // cmp    ebx, 55296
-	JE LBB0_12
-    LONG $0x80fc8141; WORD $0x0000; BYTE $0x00 // cmp    r12d, 128
-	JAE LBB0_19
+	WORD $0x014d; BYTE $0xfd                   // add    r13, r15
+	LONG $0x45b60f41; BYTE $0x02               // movzx    eax, byte [r13 + 2]
+	LONG $0x04be0f46; BYTE $0x08               // movsx    r8d, byte [rax + r9]
+	LONG $0x5db60f41; BYTE $0x03               // movzx    ebx, byte [r13 + 3]
+	LONG $0x1cbe0f42; BYTE $0x0b               // movsx    ebx, byte [rbx + r9]
+	LONG $0x45b60f41; BYTE $0x04               // movzx    eax, byte [r13 + 4]
+	LONG $0x24be0f46; BYTE $0x08               // movsx    r12d, byte [rax + r9]
+	LONG $0x45b60f41; BYTE $0x05               // movzx    eax, byte [r13 + 5]
+	LONG $0x04be0f42; BYTE $0x08               // movsx    eax, byte [rax + r9]
+	LONG $0x0ce0c141                           // shl    r8d, 12
+	WORD $0xe3c1; BYTE $0x08                   // shl    ebx, 8
+	WORD $0x0944; BYTE $0xc3                   // or    ebx, r8d
+	LONG $0x04e4c141                           // shl    r12d, 4
+	WORD $0x0941; BYTE $0xc4                   // or    r12d, eax
+	WORD $0x0941; BYTE $0xdc                   // or    r12d, ebx
+	LONG $0x06458d49                           // lea    rax, [r13 + 6]
+	WORD $0x8944; BYTE $0xe3                   // mov    ebx, r12d
+	LONG $0xfc00e381; WORD $0xffff             // and    ebx, -1024
+	LONG $0xd800fb81; WORD $0x0000             // cmp    ebx, 55296
+	JE   LBB0_12
+	LONG $0x80fc8141; WORD $0x0000; BYTE $0x00 // cmp    r12d, 128
+	JAE  LBB0_19
+
 LBB0_18:
-    LONG $0x000001be; BYTE $0x00 // mov    esi, 1
-	JMP LBB0_25
+	LONG $0x000001be; BYTE $0x00 // mov    esi, 1
+	JMP  LBB0_25
+
 LBB0_12:
-    WORD $0xfe83; BYTE $0x0c     // cmp    esi, 12
-	JB LBB0_30
-    WORD $0x3880; BYTE $0x5c     // cmp    byte [rax], 92
-	JNE LBB0_30
-    LONG $0x077d8041; BYTE $0x75 // cmp    byte [r13 + 7], 117
-	JNE LBB0_30
-    LONG $0x45b60f41; BYTE $0x08 // movzx    eax, byte [r13 + 8]
-    LONG $0x04be0f46; BYTE $0x08 // movsx    r8d, byte [rax + r9]
-    LONG $0x75b60f41; BYTE $0x09 // movzx    esi, byte [r13 + 9]
-    LONG $0x1cbe0f42; BYTE $0x0e // movsx    ebx, byte [rsi + r9]
-    LONG $0x75b60f41; BYTE $0x0a // movzx    esi, byte [r13 + 10]
-    LONG $0x34be0f42; BYTE $0x0e // movsx    esi, byte [rsi + r9]
-    LONG $0x45b60f41; BYTE $0x0b // movzx    eax, byte [r13 + 11]
-    LONG $0x04be0f42; BYTE $0x08 // movsx    eax, byte [rax + r9]
-    LONG $0x0ce0c141             // shl    r8d, 12
-    WORD $0xe3c1; BYTE $0x08     // shl    ebx, 8
-    WORD $0x0944; BYTE $0xc3     // or    ebx, r8d
-    WORD $0xe6c1; BYTE $0x04     // shl    esi, 4
-    WORD $0xc609                 // or    esi, eax
-    WORD $0xde09                 // or    esi, ebx
-    WORD $0xf089                 // mov    eax, esi
-    WORD $0x0944; BYTE $0xe0     // or    eax, r12d
-    LONG $0x00ffff3d; BYTE $0x00 // cmp    eax, 65535
-	JA LBB0_30
-    LONG $0x0ae4c141             // shl    r12d, 10
-    LONG $0x00c48141; WORD $0xa000; BYTE $0xfc // add    r12d, -56623104
-    LONG $0x2400c681; WORD $0xffff // add    esi, -56320
-    WORD $0x0944; BYTE $0xe6     // or    esi, r12d
-    LONG $0x0000c681; WORD $0x0001 // add    esi, 65536
-    LONG $0x0cc58349             // add    r13, 12
-    WORD $0x894c; BYTE $0xe8     // mov    rax, r13
-    WORD $0x8941; BYTE $0xf4     // mov    r12d, esi
-    LONG $0x80fc8141; WORD $0x0000; BYTE $0x00 // cmp    r12d, 128
-	JB LBB0_18
+	WORD $0xfe83; BYTE $0x0c                   // cmp    esi, 12
+	JB   LBB0_30
+	WORD $0x3880; BYTE $0x5c                   // cmp    byte [rax], 92
+	JNE  LBB0_30
+	LONG $0x077d8041; BYTE $0x75               // cmp    byte [r13 + 7], 117
+	JNE  LBB0_30
+	LONG $0x45b60f41; BYTE $0x08               // movzx    eax, byte [r13 + 8]
+	LONG $0x04be0f46; BYTE $0x08               // movsx    r8d, byte [rax + r9]
+	LONG $0x75b60f41; BYTE $0x09               // movzx    esi, byte [r13 + 9]
+	LONG $0x1cbe0f42; BYTE $0x0e               // movsx    ebx, byte [rsi + r9]
+	LONG $0x75b60f41; BYTE $0x0a               // movzx    esi, byte [r13 + 10]
+	LONG $0x34be0f42; BYTE $0x0e               // movsx    esi, byte [rsi + r9]
+	LONG $0x45b60f41; BYTE $0x0b               // movzx    eax, byte [r13 + 11]
+	LONG $0x04be0f42; BYTE $0x08               // movsx    eax, byte [rax + r9]
+	LONG $0x0ce0c141                           // shl    r8d, 12
+	WORD $0xe3c1; BYTE $0x08                   // shl    ebx, 8
+	WORD $0x0944; BYTE $0xc3                   // or    ebx, r8d
+	WORD $0xe6c1; BYTE $0x04                   // shl    esi, 4
+	WORD $0xc609                               // or    esi, eax
+	WORD $0xde09                               // or    esi, ebx
+	WORD $0xf089                               // mov    eax, esi
+	WORD $0x0944; BYTE $0xe0                   // or    eax, r12d
+	LONG $0x00ffff3d; BYTE $0x00               // cmp    eax, 65535
+	JA   LBB0_30
+	LONG $0x0ae4c141                           // shl    r12d, 10
+	LONG $0x00c48141; WORD $0xa000; BYTE $0xfc // add    r12d, -56623104
+	LONG $0x2400c681; WORD $0xffff             // add    esi, -56320
+	WORD $0x0944; BYTE $0xe6                   // or    esi, r12d
+	LONG $0x0000c681; WORD $0x0001             // add    esi, 65536
+	LONG $0x0cc58349                           // add    r13, 12
+	WORD $0x894c; BYTE $0xe8                   // mov    rax, r13
+	WORD $0x8941; BYTE $0xf4                   // mov    r12d, esi
+	LONG $0x80fc8141; WORD $0x0000; BYTE $0x00 // cmp    r12d, 128
+	JB   LBB0_18
+
 LBB0_19:
-    LONG $0x00fc8141; WORD $0x0008; BYTE $0x00 // cmp    r12d, 2048
-	JAE LBB0_21
-    LONG $0x000002be; BYTE $0x00 // mov    esi, 2
-	JMP LBB0_25
+	LONG $0x00fc8141; WORD $0x0008; BYTE $0x00 // cmp    r12d, 2048
+	JAE  LBB0_21
+	LONG $0x000002be; BYTE $0x00               // mov    esi, 2
+	JMP  LBB0_25
+
 LBB0_21:
-    LONG $0x00fc8141; WORD $0x0100; BYTE $0x00 // cmp    r12d, 65536
-	JAE LBB0_23
-    LONG $0x000003be; BYTE $0x00 // mov    esi, 3
-	JMP LBB0_25
+	LONG $0x00fc8141; WORD $0x0100; BYTE $0x00 // cmp    r12d, 65536
+	JAE  LBB0_23
+	LONG $0x000003be; BYTE $0x00               // mov    esi, 3
+	JMP  LBB0_25
+
 LBB0_23:
-    LONG $0xfffc8141; WORD $0x10ff; BYTE $0x00 // cmp    r12d, 1114111
-	JA LBB0_30
-    LONG $0x000004be; BYTE $0x00 // mov    esi, 4
+	LONG $0xfffc8141; WORD $0x10ff; BYTE $0x00 // cmp    r12d, 1114111
+	JA   LBB0_30
+	LONG $0x000004be; BYTE $0x00               // mov    esi, 4
+
 LBB0_25:
-    WORD $0x014d; BYTE $0xfe     // add    r14, r15
-    WORD $0x0149; BYTE $0xf6     // add    r14, rsi
+	WORD $0x014d; BYTE $0xfe // add    r14, r15
+	WORD $0x0149; BYTE $0xf6 // add    r14, rsi
+
 LBB0_29:
-    WORD $0x8948; BYTE $0xc6     // mov    rsi, rax
-    WORD $0x2948; BYTE $0xfe     // sub    rsi, rdi
-    WORD $0x8949; BYTE $0xc5     // mov    r13, rax
-    WORD $0x394c; BYTE $0xde     // cmp    rsi, r11
-	JB LBB0_2
+	WORD $0x8948; BYTE $0xc6 // mov    rsi, rax
+	WORD $0x2948; BYTE $0xfe // sub    rsi, rdi
+	WORD $0x8949; BYTE $0xc5 // mov    r13, rax
+	WORD $0x394c; BYTE $0xde // cmp    rsi, r11
+	JB   LBB0_2
+
 LBB0_30:
-    WORD $0xc031                 // xor    eax, eax
-	JMP LBB0_31
+	WORD $0xc031 // xor    eax, eax
+	JMP  LBB0_31
+
 LBB0_3:
-    WORD $0x8944; BYTE $0xe0     // mov    eax, r12d
-    LONG $0xbc0f48f3; BYTE $0xc0 // tzcnt    rax, rax
-    WORD $0x0148; BYTE $0xc6     // add    rsi, rax
-    WORD $0x8948; BYTE $0x32     // mov    qword [rdx], rsi
-    WORD $0x0149; BYTE $0xc6     // add    r14, rax
-    WORD $0x894c; BYTE $0x31     // mov    qword [rcx], r14
-    WORD $0x01b0                 // mov    al, 1
+	WORD $0x8944; BYTE $0xe0     // mov    eax, r12d
+	LONG $0xbc0f48f3; BYTE $0xc0 // tzcnt    rax, rax
+	WORD $0x0148; BYTE $0xc6     // add    rsi, rax
+	WORD $0x8948; BYTE $0x32     // mov    qword [rdx], rsi
+	WORD $0x0149; BYTE $0xc6     // add    r14, rax
+	WORD $0x894c; BYTE $0x31     // mov    qword [rcx], r14
+	WORD $0x01b0                 // mov    al, 1
+
 LBB0_31:
-    VZEROUPPER
-    MOVQ AX, result+32(FP)
-    RET
+	VZEROUPPER
+	MOVQ AX, result+32(FP)
+	RET
 
 TEXT ·_parse_string(SB), $0-32
 
-    MOVQ src+0(FP), DI
-    MOVQ dst+8(FP), SI
-    MOVQ pcurrent_string_buf_loc+16(FP), DX
-    LEAQ LCDATA1<>(SB), BP
+	MOVQ src+0(FP), DI
+	MOVQ dst+8(FP), SI
+	MOVQ pcurrent_string_buf_loc+16(FP), DX
+	LEAQ LCDATA1<>(SB), BP
 
-    LONG $0x076ffec5             // vmovdqu    ymm0, yword [rdi]
-    LONG $0x067ffec5             // vmovdqu    yword [rsi], ymm0
-    LONG $0x4d74fdc5; BYTE $0x00 // vpcmpeqb    ymm1, ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
-    LONG $0xc9d7fdc5             // vpmovmskb    ecx, ymm1
-    LONG $0x4574fdc5; BYTE $0x20 // vpcmpeqb    ymm0, ymm0, yword 32[rbp] /* [rip + LCPI0_1] */
-    LONG $0xf0d77dc5             // vpmovmskb    r14d, ymm0
-    WORD $0x418d; BYTE $0xff     // lea    eax, [rcx - 1]
-    WORD $0x8544; BYTE $0xf0     // test    eax, r14d
-	JE LBB0_3
+	LONG $0x076ffec5             // vmovdqu    ymm0, yword [rdi]
+	LONG $0x067ffec5             // vmovdqu    yword [rsi], ymm0
+	LONG $0x4d74fdc5; BYTE $0x00 // vpcmpeqb    ymm1, ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
+	LONG $0xc9d7fdc5             // vpmovmskb    ecx, ymm1
+	LONG $0x4574fdc5; BYTE $0x20 // vpcmpeqb    ymm0, ymm0, yword 32[rbp] /* [rip + LCPI0_1] */
+	LONG $0xf0d77dc5             // vpmovmskb    r14d, ymm0
+	WORD $0x418d; BYTE $0xff     // lea    eax, [rcx - 1]
+	WORD $0x8544; BYTE $0xf0     // test    eax, r14d
+	JE   LBB0_3
+
 LBB0_1:
-    WORD $0x8944; BYTE $0xf0     // mov    eax, r14d
-    LONG $0xbc0f48f3; BYTE $0xc0 // tzcnt    rax, rax
-    WORD $0x0148; BYTE $0xf0     // add    rax, rsi
-    WORD $0x8948; BYTE $0x02     // mov    qword [rdx], rax
-    LONG $0x000001b8; BYTE $0x00 // mov    eax, 1
+	WORD $0x8944; BYTE $0xf0     // mov    eax, r14d
+	LONG $0xbc0f48f3; BYTE $0xc0 // tzcnt    rax, rax
+	WORD $0x0148; BYTE $0xf0     // add    rax, rsi
+	WORD $0x8948; BYTE $0x02     // mov    qword [rdx], rax
+	LONG $0x000001b8; BYTE $0x00 // mov    eax, 1
+
 LBB0_2:
-    VZEROUPPER
-    MOVQ AX, res+24(FP)
-    RET
+	VZEROUPPER
+	MOVQ AX, res+24(FP)
+	RET
+
 LBB0_3:
-    LONG $0x456ffdc5; BYTE $0x00 // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
-    LONG $0x4d6ffdc5; BYTE $0x20 // vmovdqa    ymm1, yword 32[rbp] /* [rip + LCPI0_1] */
-    WORD $0xc031                 // xor    eax, eax
-    LONG $0x40658d4c             // lea    r12, 64[rbp] /* [rip + __ZL10digittoval] */
-    LONG $0x0001b941; WORD $0x0000 // mov    r9d, 1
-    LONG $0x0002ba41; WORD $0x0000 // mov    r10d, 2
-    LONG $0x40bd8d4c; WORD $0x0001; BYTE $0x00 // lea    r15, 320[rbp] /* [rip + __ZL10escape_map] */
-	JMP LBB0_4
+	LONG $0x456ffdc5; BYTE $0x00               // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
+	LONG $0x4d6ffdc5; BYTE $0x20               // vmovdqa    ymm1, yword 32[rbp] /* [rip + LCPI0_1] */
+	WORD $0xc031                               // xor    eax, eax
+	LONG $0x40658d4c                           // lea    r12, 64[rbp] /* [rip + __ZL10digittoval] */
+	LONG $0x0001b941; WORD $0x0000             // mov    r9d, 1
+	LONG $0x0002ba41; WORD $0x0000             // mov    r10d, 2
+	LONG $0x40bd8d4c; WORD $0x0001; BYTE $0x00 // lea    r15, 320[rbp] /* [rip + __ZL10escape_map] */
+	JMP  LBB0_4
+
 LBB0_24:
-    LONG $0xfff88141; WORD $0x00ff; BYTE $0x00 // cmp    r8d, 65535
-	JA LBB0_26
-    WORD $0x8944; BYTE $0xc1     // mov    ecx, r8d
-    WORD $0xe9c1; BYTE $0x0c     // shr    ecx, 12
-    LONG $0x00e0c181; WORD $0x0000 // add    ecx, 224
-    WORD $0x0e88                 // mov    byte [rsi], cl
-    WORD $0x8944; BYTE $0xc1     // mov    ecx, r8d
-    WORD $0xe9c1; BYTE $0x06     // shr    ecx, 6
-    WORD $0xe180; BYTE $0x3f     // and    cl, 63
-    WORD $0xc980; BYTE $0x80     // or    cl, -128
-    WORD $0x4e88; BYTE $0x01     // mov    byte [rsi + 1], cl
-    LONG $0x3fe08041             // and    r8b, 63
-    LONG $0x80c88041             // or    r8b, -128
-    LONG $0x02468844             // mov    byte [rsi + 2], r8b
-    LONG $0x000003b9; BYTE $0x00 // mov    ecx, 3
-	JMP LBB0_28
+	LONG $0xfff88141; WORD $0x00ff; BYTE $0x00 // cmp    r8d, 65535
+	JA   LBB0_26
+	WORD $0x8944; BYTE $0xc1                   // mov    ecx, r8d
+	WORD $0xe9c1; BYTE $0x0c                   // shr    ecx, 12
+	LONG $0x00e0c181; WORD $0x0000             // add    ecx, 224
+	WORD $0x0e88                               // mov    byte [rsi], cl
+	WORD $0x8944; BYTE $0xc1                   // mov    ecx, r8d
+	WORD $0xe9c1; BYTE $0x06                   // shr    ecx, 6
+	WORD $0xe180; BYTE $0x3f                   // and    cl, 63
+	WORD $0xc980; BYTE $0x80                   // or    cl, -128
+	WORD $0x4e88; BYTE $0x01                   // mov    byte [rsi + 1], cl
+	LONG $0x3fe08041                           // and    r8b, 63
+	LONG $0x80c88041                           // or    r8b, -128
+	LONG $0x02468844                           // mov    byte [rsi + 2], r8b
+	LONG $0x000003b9; BYTE $0x00               // mov    ecx, 3
+	JMP  LBB0_28
+
 LBB0_26:
-    LONG $0xfff88141; WORD $0x10ff; BYTE $0x00 // cmp    r8d, 1114111
-	JA LBB0_2
-    WORD $0x8944; BYTE $0xc1     // mov    ecx, r8d
-    WORD $0xe9c1; BYTE $0x12     // shr    ecx, 18
-    LONG $0x00f0c181; WORD $0x0000 // add    ecx, 240
-    WORD $0x0e88                 // mov    byte [rsi], cl
-    WORD $0x8944; BYTE $0xc1     // mov    ecx, r8d
-    WORD $0xe9c1; BYTE $0x0c     // shr    ecx, 12
-    WORD $0xe180; BYTE $0x3f     // and    cl, 63
-    WORD $0xc980; BYTE $0x80     // or    cl, -128
-    WORD $0x4e88; BYTE $0x01     // mov    byte [rsi + 1], cl
-    WORD $0x8944; BYTE $0xc1     // mov    ecx, r8d
-    WORD $0xe9c1; BYTE $0x06     // shr    ecx, 6
-    WORD $0xe180; BYTE $0x3f     // and    cl, 63
-    WORD $0xc980; BYTE $0x80     // or    cl, -128
-    WORD $0x4e88; BYTE $0x02     // mov    byte [rsi + 2], cl
-    LONG $0x3fe08041             // and    r8b, 63
-    LONG $0x80c88041             // or    r8b, -128
-    LONG $0x03468844             // mov    byte [rsi + 3], r8b
-    LONG $0x000004b9; BYTE $0x00 // mov    ecx, 4
-	JMP LBB0_28
+	LONG $0xfff88141; WORD $0x10ff; BYTE $0x00 // cmp    r8d, 1114111
+	JA   LBB0_2
+	WORD $0x8944; BYTE $0xc1                   // mov    ecx, r8d
+	WORD $0xe9c1; BYTE $0x12                   // shr    ecx, 18
+	LONG $0x00f0c181; WORD $0x0000             // add    ecx, 240
+	WORD $0x0e88                               // mov    byte [rsi], cl
+	WORD $0x8944; BYTE $0xc1                   // mov    ecx, r8d
+	WORD $0xe9c1; BYTE $0x0c                   // shr    ecx, 12
+	WORD $0xe180; BYTE $0x3f                   // and    cl, 63
+	WORD $0xc980; BYTE $0x80                   // or    cl, -128
+	WORD $0x4e88; BYTE $0x01                   // mov    byte [rsi + 1], cl
+	WORD $0x8944; BYTE $0xc1                   // mov    ecx, r8d
+	WORD $0xe9c1; BYTE $0x06                   // shr    ecx, 6
+	WORD $0xe180; BYTE $0x3f                   // and    cl, 63
+	WORD $0xc980; BYTE $0x80                   // or    cl, -128
+	WORD $0x4e88; BYTE $0x02                   // mov    byte [rsi + 2], cl
+	LONG $0x3fe08041                           // and    r8b, 63
+	LONG $0x80c88041                           // or    r8b, -128
+	LONG $0x03468844                           // mov    byte [rsi + 3], r8b
+	LONG $0x000004b9; BYTE $0x00               // mov    ecx, 4
+	JMP  LBB0_28
+
 LBB0_4:
-    LONG $0xff5e8d41             // lea    ebx, [r14 - 1]
-    WORD $0xcb85                 // test    ebx, ecx
-	JE LBB0_8
-    WORD $0xc989                 // mov    ecx, ecx
-    LONG $0xbc0f4cf3; BYTE $0xd9 // tzcnt    r11, rcx
-    LONG $0x4cb60f42; WORD $0x011f // movzx    ecx, byte [rdi + r11 + 1]
-    LONG $0x75f98348             // cmp    rcx, 117
-	JNE LBB0_9
-    WORD $0x8545; BYTE $0xf6     // test    r14d, r14d
-	JE LBB0_11
-    WORD $0x8944; BYTE $0xf1     // mov    ecx, r14d
-    LONG $0xbc0f4cf3; BYTE $0xf1 // tzcnt    r14, rcx
-    WORD $0x2945; BYTE $0xde     // sub    r14d, r11d
-    LONG $0x06fe8341             // cmp    r14d, 6
-	JAE LBB0_14
-	JMP LBB0_2
+	LONG $0xff5e8d41               // lea    ebx, [r14 - 1]
+	WORD $0xcb85                   // test    ebx, ecx
+	JE   LBB0_8
+	WORD $0xc989                   // mov    ecx, ecx
+	LONG $0xbc0f4cf3; BYTE $0xd9   // tzcnt    r11, rcx
+	LONG $0x4cb60f42; WORD $0x011f // movzx    ecx, byte [rdi + r11 + 1]
+	LONG $0x75f98348               // cmp    rcx, 117
+	JNE  LBB0_9
+	WORD $0x8545; BYTE $0xf6       // test    r14d, r14d
+	JE   LBB0_11
+	WORD $0x8944; BYTE $0xf1       // mov    ecx, r14d
+	LONG $0xbc0f4cf3; BYTE $0xf1   // tzcnt    r14, rcx
+	WORD $0x2945; BYTE $0xde       // sub    r14d, r11d
+	LONG $0x06fe8341               // cmp    r14d, 6
+	JAE  LBB0_14
+	JMP  LBB0_2
+
 LBB0_8:
-    LONG $0x20c78348             // add    rdi, 32
-    LONG $0x20c68348             // add    rsi, 32
-    WORD $0x8949; BYTE $0xfd     // mov    r13, rdi
-	JMP LBB0_29
+	LONG $0x20c78348         // add    rdi, 32
+	LONG $0x20c68348         // add    rsi, 32
+	WORD $0x8949; BYTE $0xfd // mov    r13, rdi
+	JMP  LBB0_29
+
 LBB0_9:
-    LONG $0x0cb60f42; BYTE $0x39 // movzx    ecx, byte [rcx + r15]
-    WORD $0xc984                 // test    cl, cl
-	JE LBB0_2
-    LONG $0x1e0c8842             // mov    byte [rsi + r11], cl
-    LONG $0x1f6c8d4e; BYTE $0x02 // lea    r13, [rdi + r11 + 2]
-    LONG $0x014b8d49             // lea    rcx, [r11 + 1]
+	LONG $0x0cb60f42; BYTE $0x39 // movzx    ecx, byte [rcx + r15]
+	WORD $0xc984                 // test    cl, cl
+	JE   LBB0_2
+	LONG $0x1e0c8842             // mov    byte [rsi + r11], cl
+	LONG $0x1f6c8d4e; BYTE $0x02 // lea    r13, [rdi + r11 + 2]
+	LONG $0x014b8d49             // lea    rcx, [r11 + 1]
+
 LBB0_28:
-    WORD $0x0148; BYTE $0xce     // add    rsi, rcx
-	JMP LBB0_29
+	WORD $0x0148; BYTE $0xce // add    rsi, rcx
+	JMP  LBB0_29
+
 LBB0_11:
-    LONG $0x0020be41; WORD $0x0000 // mov    r14d, 32
-    LONG $0x15fb8341             // cmp    r11d, 21
-	JB LBB0_13
-    LONG $0xec4b8d41             // lea    ecx, [r11 - 20]
-    LONG $0x1474f5c5; BYTE $0x0f // vpcmpeqb    ymm2, ymm1, yword [rdi + rcx]
-    LONG $0xcad7fdc5             // vpmovmskb    ecx, ymm2
-    LONG $0xbc0f48f3; BYTE $0xd9 // tzcnt    rbx, rcx
-    WORD $0xc985                 // test    ecx, ecx
-    LONG $0x000020b9; BYTE $0x00 // mov    ecx, 32
-    WORD $0x440f; BYTE $0xd9     // cmove    ebx, ecx
-    LONG $0x1b748d46; BYTE $0xec // lea    r14d, [rbx + r11 - 20]
+	LONG $0x0020be41; WORD $0x0000 // mov    r14d, 32
+	LONG $0x15fb8341               // cmp    r11d, 21
+	JB   LBB0_13
+	LONG $0xec4b8d41               // lea    ecx, [r11 - 20]
+	LONG $0x1474f5c5; BYTE $0x0f   // vpcmpeqb    ymm2, ymm1, yword [rdi + rcx]
+	LONG $0xcad7fdc5               // vpmovmskb    ecx, ymm2
+	LONG $0xbc0f48f3; BYTE $0xd9   // tzcnt    rbx, rcx
+	WORD $0xc985                   // test    ecx, ecx
+	LONG $0x000020b9; BYTE $0x00   // mov    ecx, 32
+	WORD $0x440f; BYTE $0xd9       // cmove    ebx, ecx
+	LONG $0x1b748d46; BYTE $0xec   // lea    r14d, [rbx + r11 - 20]
+
 LBB0_13:
-    WORD $0x2945; BYTE $0xde     // sub    r14d, r11d
-    LONG $0x06fe8341             // cmp    r14d, 6
-	JB LBB0_2
+	WORD $0x2945; BYTE $0xde // sub    r14d, r11d
+	LONG $0x06fe8341         // cmp    r14d, 6
+	JB   LBB0_2
+
 LBB0_14:
-    WORD $0x014c; BYTE $0xdf     // add    rdi, r11
-    LONG $0x024fb60f             // movzx    ecx, byte [rdi + 2]
-    LONG $0x2cbe0f46; BYTE $0x21 // movsx    r13d, byte [rcx + r12]
-    LONG $0x035fb60f             // movzx    ebx, byte [rdi + 3]
-    LONG $0x1cbe0f42; BYTE $0x23 // movsx    ebx, byte [rbx + r12]
-    LONG $0x044fb60f             // movzx    ecx, byte [rdi + 4]
-    LONG $0x04be0f46; BYTE $0x21 // movsx    r8d, byte [rcx + r12]
-    LONG $0x054fb60f             // movzx    ecx, byte [rdi + 5]
-    LONG $0x0cbe0f42; BYTE $0x21 // movsx    ecx, byte [rcx + r12]
-    LONG $0x0ce5c141             // shl    r13d, 12
-    WORD $0xe3c1; BYTE $0x08     // shl    ebx, 8
-    WORD $0x0944; BYTE $0xeb     // or    ebx, r13d
-    LONG $0x04e0c141             // shl    r8d, 4
-    WORD $0x0941; BYTE $0xc8     // or    r8d, ecx
-    WORD $0x0941; BYTE $0xd8     // or    r8d, ebx
-    LONG $0x066f8d4c             // lea    r13, [rdi + 6]
-    WORD $0x8944; BYTE $0xc1     // mov    ecx, r8d
-    LONG $0xfc00e181; WORD $0xffff // and    ecx, -1024
-    LONG $0xd800f981; WORD $0x0000 // cmp    ecx, 55296
-	JNE LBB0_20
-    LONG $0x0cfe8341             // cmp    r14d, 12
-	JB LBB0_2
-    LONG $0x007d8041; BYTE $0x5c // cmp    byte [r13], 92
-	JNE LBB0_2
-    LONG $0x75077f80             // cmp    byte [rdi + 7], 117
-	JNE LBB0_2
-    LONG $0x084fb60f             // movzx    ecx, byte [rdi + 8]
-    LONG $0x34be0f46; BYTE $0x21 // movsx    r14d, byte [rcx + r12]
-    LONG $0x094fb60f             // movzx    ecx, byte [rdi + 9]
-    LONG $0x2cbe0f46; BYTE $0x21 // movsx    r13d, byte [rcx + r12]
-    LONG $0x0a4fb60f             // movzx    ecx, byte [rdi + 10]
-    LONG $0x0cbe0f42; BYTE $0x21 // movsx    ecx, byte [rcx + r12]
-    LONG $0x0b5fb60f             // movzx    ebx, byte [rdi + 11]
-    LONG $0x1cbe0f42; BYTE $0x23 // movsx    ebx, byte [rbx + r12]
-    LONG $0x0ce6c141             // shl    r14d, 12
-    LONG $0x08e5c141             // shl    r13d, 8
-    WORD $0x0945; BYTE $0xf5     // or    r13d, r14d
-    WORD $0xe1c1; BYTE $0x04     // shl    ecx, 4
-    WORD $0xd909                 // or    ecx, ebx
-    WORD $0x0944; BYTE $0xe9     // or    ecx, r13d
-    WORD $0xcb89                 // mov    ebx, ecx
-    WORD $0x0944; BYTE $0xc3     // or    ebx, r8d
-    LONG $0xfffffb81; WORD $0x0000 // cmp    ebx, 65535
-	JA LBB0_2
-    LONG $0x0ae0c141             // shl    r8d, 10
-    LONG $0x00c08141; WORD $0xa000; BYTE $0xfc // add    r8d, -56623104
-    LONG $0x2400c181; WORD $0xffff // add    ecx, -56320
-    WORD $0x0944; BYTE $0xc1     // or    ecx, r8d
-    LONG $0x0000c181; WORD $0x0001 // add    ecx, 65536
-    LONG $0x0cc78348             // add    rdi, 12
-    WORD $0x8949; BYTE $0xfd     // mov    r13, rdi
-    WORD $0x8941; BYTE $0xc8     // mov    r8d, ecx
+	WORD $0x014c; BYTE $0xdf                   // add    rdi, r11
+	LONG $0x024fb60f                           // movzx    ecx, byte [rdi + 2]
+	LONG $0x2cbe0f46; BYTE $0x21               // movsx    r13d, byte [rcx + r12]
+	LONG $0x035fb60f                           // movzx    ebx, byte [rdi + 3]
+	LONG $0x1cbe0f42; BYTE $0x23               // movsx    ebx, byte [rbx + r12]
+	LONG $0x044fb60f                           // movzx    ecx, byte [rdi + 4]
+	LONG $0x04be0f46; BYTE $0x21               // movsx    r8d, byte [rcx + r12]
+	LONG $0x054fb60f                           // movzx    ecx, byte [rdi + 5]
+	LONG $0x0cbe0f42; BYTE $0x21               // movsx    ecx, byte [rcx + r12]
+	LONG $0x0ce5c141                           // shl    r13d, 12
+	WORD $0xe3c1; BYTE $0x08                   // shl    ebx, 8
+	WORD $0x0944; BYTE $0xeb                   // or    ebx, r13d
+	LONG $0x04e0c141                           // shl    r8d, 4
+	WORD $0x0941; BYTE $0xc8                   // or    r8d, ecx
+	WORD $0x0941; BYTE $0xd8                   // or    r8d, ebx
+	LONG $0x066f8d4c                           // lea    r13, [rdi + 6]
+	WORD $0x8944; BYTE $0xc1                   // mov    ecx, r8d
+	LONG $0xfc00e181; WORD $0xffff             // and    ecx, -1024
+	LONG $0xd800f981; WORD $0x0000             // cmp    ecx, 55296
+	JNE  LBB0_20
+	LONG $0x0cfe8341                           // cmp    r14d, 12
+	JB   LBB0_2
+	LONG $0x007d8041; BYTE $0x5c               // cmp    byte [r13], 92
+	JNE  LBB0_2
+	LONG $0x75077f80                           // cmp    byte [rdi + 7], 117
+	JNE  LBB0_2
+	LONG $0x084fb60f                           // movzx    ecx, byte [rdi + 8]
+	LONG $0x34be0f46; BYTE $0x21               // movsx    r14d, byte [rcx + r12]
+	LONG $0x094fb60f                           // movzx    ecx, byte [rdi + 9]
+	LONG $0x2cbe0f46; BYTE $0x21               // movsx    r13d, byte [rcx + r12]
+	LONG $0x0a4fb60f                           // movzx    ecx, byte [rdi + 10]
+	LONG $0x0cbe0f42; BYTE $0x21               // movsx    ecx, byte [rcx + r12]
+	LONG $0x0b5fb60f                           // movzx    ebx, byte [rdi + 11]
+	LONG $0x1cbe0f42; BYTE $0x23               // movsx    ebx, byte [rbx + r12]
+	LONG $0x0ce6c141                           // shl    r14d, 12
+	LONG $0x08e5c141                           // shl    r13d, 8
+	WORD $0x0945; BYTE $0xf5                   // or    r13d, r14d
+	WORD $0xe1c1; BYTE $0x04                   // shl    ecx, 4
+	WORD $0xd909                               // or    ecx, ebx
+	WORD $0x0944; BYTE $0xe9                   // or    ecx, r13d
+	WORD $0xcb89                               // mov    ebx, ecx
+	WORD $0x0944; BYTE $0xc3                   // or    ebx, r8d
+	LONG $0xfffffb81; WORD $0x0000             // cmp    ebx, 65535
+	JA   LBB0_2
+	LONG $0x0ae0c141                           // shl    r8d, 10
+	LONG $0x00c08141; WORD $0xa000; BYTE $0xfc // add    r8d, -56623104
+	LONG $0x2400c181; WORD $0xffff             // add    ecx, -56320
+	WORD $0x0944; BYTE $0xc1                   // or    ecx, r8d
+	LONG $0x0000c181; WORD $0x0001             // add    ecx, 65536
+	LONG $0x0cc78348                           // add    rdi, 12
+	WORD $0x8949; BYTE $0xfd                   // mov    r13, rdi
+	WORD $0x8941; BYTE $0xc8                   // mov    r8d, ecx
+
 LBB0_20:
-    WORD $0x014c; BYTE $0xde     // add    rsi, r11
-    LONG $0x7ff88341             // cmp    r8d, 127
-	JA LBB0_22
-    WORD $0x8844; BYTE $0x06     // mov    byte [rsi], r8b
-    WORD $0x014c; BYTE $0xce     // add    rsi, r9
-	JMP LBB0_29
+	WORD $0x014c; BYTE $0xde // add    rsi, r11
+	LONG $0x7ff88341         // cmp    r8d, 127
+	JA   LBB0_22
+	WORD $0x8844; BYTE $0x06 // mov    byte [rsi], r8b
+	WORD $0x014c; BYTE $0xce // add    rsi, r9
+	JMP  LBB0_29
+
 LBB0_22:
-    LONG $0xfff88141; WORD $0x0007; BYTE $0x00 // cmp    r8d, 2047
-	JA LBB0_24
-    WORD $0x8944; BYTE $0xc1     // mov    ecx, r8d
-    WORD $0xe9c1; BYTE $0x06     // shr    ecx, 6
-    LONG $0x00c0c181; WORD $0x0000 // add    ecx, 192
-    WORD $0x0e88                 // mov    byte [rsi], cl
-    LONG $0x3fe08041             // and    r8b, 63
-    LONG $0x80c88041             // or    r8b, -128
-    LONG $0x01468844             // mov    byte [rsi + 1], r8b
-    WORD $0x014c; BYTE $0xd6     // add    rsi, r10
+	LONG $0xfff88141; WORD $0x0007; BYTE $0x00 // cmp    r8d, 2047
+	JA   LBB0_24
+	WORD $0x8944; BYTE $0xc1                   // mov    ecx, r8d
+	WORD $0xe9c1; BYTE $0x06                   // shr    ecx, 6
+	LONG $0x00c0c181; WORD $0x0000             // add    ecx, 192
+	WORD $0x0e88                               // mov    byte [rsi], cl
+	LONG $0x3fe08041                           // and    r8b, 63
+	LONG $0x80c88041                           // or    r8b, -128
+	LONG $0x01468844                           // mov    byte [rsi + 1], r8b
+	WORD $0x014c; BYTE $0xd6                   // add    rsi, r10
+
 LBB0_29:
-    LONG $0x6f7ec1c4; WORD $0x0055 // vmovdqu    ymm2, yword [r13]
-    LONG $0x167ffec5             // vmovdqu    yword [rsi], ymm2
-    LONG $0xd874edc5             // vpcmpeqb    ymm3, ymm2, ymm0
-    LONG $0xcbd7fdc5             // vpmovmskb    ecx, ymm3
-    LONG $0xd174edc5             // vpcmpeqb    ymm2, ymm2, ymm1
-    LONG $0xf2d77dc5             // vpmovmskb    r14d, ymm2
-    WORD $0x598d; BYTE $0xff     // lea    ebx, [rcx - 1]
-    WORD $0x894c; BYTE $0xef     // mov    rdi, r13
-    WORD $0x8544; BYTE $0xf3     // test    ebx, r14d
-	JE LBB0_4
-	JMP LBB0_1
+	LONG $0x6f7ec1c4; WORD $0x0055 // vmovdqu    ymm2, yword [r13]
+	LONG $0x167ffec5               // vmovdqu    yword [rsi], ymm2
+	LONG $0xd874edc5               // vpcmpeqb    ymm3, ymm2, ymm0
+	LONG $0xcbd7fdc5               // vpmovmskb    ecx, ymm3
+	LONG $0xd174edc5               // vpcmpeqb    ymm2, ymm2, ymm1
+	LONG $0xf2d77dc5               // vpmovmskb    r14d, ymm2
+	WORD $0x598d; BYTE $0xff       // lea    ebx, [rcx - 1]
+	WORD $0x894c; BYTE $0xef       // mov    rdi, r13
+	WORD $0x8544; BYTE $0xf3       // test    ebx, r14d
+	JE   LBB0_4
+	JMP  LBB0_1


### PR DESCRIPTION
Run `github.com/klauspost/asmfmt/cmd/asmfmt`.

Note that only `find_odd_backslash_sequences_amd64.s` file was self-edted after run asmfmt because there are `Y8 => (DI)` and `Y9 => (SI)` inline hints.

```assembly
	VPCMPEQB  Y8/*(DI)*/, Y0, Y1  // vpcmpeqb    ymm1, ymm0, yword [rdi]
	VPMOVMSKB Y1, CX              // vpmovmskb    ecx, ymm1
	VPCMPEQB  Y9/*(SI)*/, Y0, Y0  // vpcmpeqb    ymm0, ymm0, yword [rsi]
```