### PR TITLE
Fix number parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,6 @@ For string values without special characters the tape's payload points directly 
 
 For more information, see `TestStage2BuildTape` in `stage2_build_tape_test.go`.
 
-## Minor number inprecisions
-
-The number parser has minor inprecisions compared to Golang's standard number parsing. 
-There is constant `GOLANG_NUMBER_PARSING` (on by default) that uses Go's 
-parsing functionality at the expense of giving up some performance. 
-Note that the performance metrics mentioned above have been measured by setting the `GOLANG_NUMBER_PARSING` to `false`.
-
 ## Non streaming use cases
 
 The best performance is obtained by keeping the JSON message fully mapped in memory and setting the

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/json-iterator/go v1.1.9
-	github.com/klauspost/compress v1.10.1
+	github.com/klauspost/compress v1.11.7
 	github.com/klauspost/cpuid/v2 v2.0.3
 	github.com/mmcloughlin/avo v0.0.0-20201105074841-5d2f697d268f // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.13
 require (
 	github.com/json-iterator/go v1.1.9
 	github.com/klauspost/compress v1.10.1
-	github.com/klauspost/cpuid v1.2.2
+	github.com/klauspost/cpuid/v2 v2.0.3
 	github.com/mmcloughlin/avo v0.0.0-20201105074841-5d2f697d268f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/klauspost/compress v1.10.1 h1:a/QY0o9S6wCi0XhxaMX/QmusicNUqCqFugR6WKP
 github.com/klauspost/compress v1.10.1/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.2 h1:1xAgYebNnsb9LKCdLOvFWtAxGU/33mjJtyOVbmUa0Us=
 github.com/klauspost/cpuid v1.2.2/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid/v2 v2.0.3 h1:DNljyrHyxlkk8139OXIAAauCwV8eQGDD6Z8YqnDXdZw=
+github.com/klauspost/cpuid/v2 v2.0.3/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/mmcloughlin/avo v0.0.0-20201105074841-5d2f697d268f h1:D4I34fbgczGrhrN4DzBCZXT3u/nMWJnGmviIjSzzXSw=
 github.com/mmcloughlin/avo v0.0.0-20201105074841-5d2f697d268f/go.mod h1:6aKT4zZIrpGqB3RpFU14ByCSSyKY6LfJz4J/JJChHfI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGn
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/klauspost/compress v1.10.1 h1:a/QY0o9S6wCi0XhxaMX/QmusicNUqCqFugR6WKPOSoQ=
 github.com/klauspost/compress v1.10.1/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
+github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.2 h1:1xAgYebNnsb9LKCdLOvFWtAxGU/33mjJtyOVbmUa0Us=
 github.com/klauspost/cpuid v1.2.2/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.3 h1:DNljyrHyxlkk8139OXIAAauCwV8eQGDD6Z8YqnDXdZw=

--- a/parse_json_amd64_test.go
+++ b/parse_json_amd64_test.go
@@ -22,10 +22,12 @@ package simdjson
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"reflect"
+	"math"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -152,121 +154,47 @@ func BenchmarkNdjsonColdCountStarWithWhere(b *testing.B) {
 }
 
 func TestParseNumber(t *testing.T) {
-
-	if GOLANG_NUMBER_PARSING {
-		t.Skip()
-	}
-
 	testCases := []struct {
 		input     string
-		is_double bool
+		wantTag   Tag
 		expectedD float64
-		expectedI int
+		expectedI int64
+		expectedU uint64
 	}{
-		{"1", false, 0.0, 1},
-		{"-1", false, 0.0, -1},
-		{"1.0", true, 1.0, 0},
-		{"1234567890", false, 0.0, 1234567890},
-		{"9876.543210", true, 9876.543210, 0},
-		{"0.123456789e-12", true, 1.23456789e-13, 0},
-		{"1.234567890E+34", true, 1.234567890e+34, 0},
-		{"23456789012E66", true, 23456789012e66, 0},
-		{"-9876.543210", true, -9876.543210, 0},
-		// The number below parses to -65.61972000000004 for parse_number()
-		// This extra inprecision is tolerated when GOLANG_NUMBER_PARSING = false
-		{"-65.619720000000029", true, -65.61972000000003, 0},
+		{"1", TagInteger, 0.0, 1, 0},
+		{"-1", TagInteger, 0.0, -1, 0},
+		{"10000000000000000000", TagUint, 0.0, 0, 10000000000000000000},
+		{"10000000000000000001", TagUint, 0.0, 0, 10000000000000000001},
+		{"-10000000000000000000", TagFloat, -10000000000000000000, 0, 0},
+		{"1.0", TagFloat, 1.0, 0, 0},
+		{"1234567890", TagInteger, 0.0, 1234567890, 0},
+		{"9876.543210", TagFloat, 9876.543210, 0, 0},
+		{"0.123456789e-12", TagFloat, 1.23456789e-13, 0, 0},
+		{"1.234567890E+34", TagFloat, 1.234567890e+34, 0, 0},
+		{"23456789012E66", TagFloat, 23456789012e66, 0, 0},
+		{"-9876.543210", TagFloat, -9876.543210, 0, 0},
+		{"-65.619720000000029", TagFloat, -65.61972000000003, 0, 0},
 	}
 
 	for _, tc := range testCases {
-		found_minus := false
-		if tc.input[0] == '-' {
-			found_minus = true
+		tag, val := parseNumber([]byte(fmt.Sprintf(`%s:`, tc.input)))
+		if tag != tc.wantTag {
+			t.Errorf("TestParseNumber: got: %v want: %v", tag, tc.wantTag)
 		}
-		succes, is_double, d, i := parse_number_simd([]byte(fmt.Sprintf(`%s:`, tc.input)), found_minus)
-		if !succes {
-			t.Errorf("TestParseNumber: got: %v want: %v", succes, true)
-		}
-		if is_double != tc.is_double {
-			t.Errorf("TestParseNumber: got: %v want: %v", is_double, tc.is_double)
-		}
-		if is_double {
-			if !closeEnough(d, tc.expectedD) {
-				if GOLANG_NUMBER_PARSING {
-					t.Errorf("TestParseNumber: got: %g want: %g", d, tc.expectedD)
-				} else {
-					if !closeEnoughLessPrecision(d, tc.expectedD) {
-						t.Errorf("TestParseNumber: got: %g want: %g", d, tc.expectedD)
-					}
-				}
+		switch tag {
+		case TagFloat:
+			got := math.Float64frombits(val)
+			if !closeEnough(got, tc.expectedD) {
+				t.Errorf("TestParseNumber: got: %g want: %g", got, tc.expectedD)
 			}
-		} else {
-			if i != tc.expectedI {
-				t.Errorf("TestParseNumber: got: %d want: %d", i, tc.expectedI)
+		case TagInteger:
+			if tc.expectedI != int64(val) {
+				t.Errorf("TestParseNumber: got: %d want: %d", int64(val), tc.expectedI)
 			}
-		}
-	}
-}
-
-func TestParseInt64(t *testing.T) {
-
-	if GOLANG_NUMBER_PARSING {
-		t.Skip()
-	}
-
-	for i := range parseInt64Tests {
-		test := &parseInt64Tests[i]
-
-		found_minus := false
-		if test.in[0] == '-' {
-			found_minus = true
-		}
-		succes, is_double, _, i := parse_number_simd([]byte(fmt.Sprintf(`%s:`, test.in)), found_minus)
-		if !succes {
-			// Ignore intentionally bad syntactical errors
-			if !reflect.DeepEqual(test.err, strconv.ErrSyntax) {
-				t.Errorf("TestParseInt64: got: %v want: %v", succes, true)
+		case TagUint:
+			if tc.expectedU != val {
+				t.Errorf("TestParseNumber: got: %d want: %d", val, tc.expectedU)
 			}
-			continue // skip testing the rest for this test case
-		}
-		if is_double {
-			t.Errorf("TestParseInt64: got: %v want: %v", is_double, false)
-		}
-		if i != test.out {
-			// Ignore intentionally wrong conversions
-			if !reflect.DeepEqual(test.err, strconv.ErrRange) {
-				t.Errorf("TestParseInt64: got: %v want: %v", i, test.out)
-			}
-		}
-	}
-}
-
-func TestParseFloat64(t *testing.T) {
-
-	if GOLANG_NUMBER_PARSING {
-		t.Skip()
-	}
-
-	for i := 0; i < len(atoftests); i++ {
-		test := &atoftests[i]
-
-		found_minus := false
-		if test.in[0] == '-' {
-			found_minus = true
-		}
-		succes, is_double, d, _ := parse_number_simd([]byte(fmt.Sprintf(`%s:`, test.in)), found_minus)
-		if !succes {
-			// Ignore intentionally bad syntactical errors
-			if !reflect.DeepEqual(test.err, strconv.ErrSyntax) {
-				t.Errorf("TestParseFloat64: got: %v want: %v", succes, true)
-			}
-			continue // skip testing the rest for this test case
-		}
-		if !is_double {
-			t.Errorf("TestParseFloat64: got: %v want: %v", is_double, true)
-		}
-		outs := strconv.FormatFloat(d, 'g', -1, 64)
-		if outs != test.out {
-			t.Errorf("TestParseFloat64: got: %v want: %v", d, test.out)
 		}
 	}
 }
@@ -275,41 +203,61 @@ func TestParseFloat64(t *testing.T) {
 
 type parseInt64Test struct {
 	in  string
-	out int
-	err error
+	out int64
+	tag Tag
 }
 
 var parseInt64Tests = []parseInt64Test{
-	//	{"", 0, strconv.ErrSyntax},                                  /* fails for simdjson */
-	{"0", 0, nil},
-	{"-0", 0, nil},
-	{"1", 1, nil},
-	{"-1", -1, nil},
-	{"12345", 12345, nil},
-	{"-12345", -12345, nil},
-	//	{"012345", 12345, nil},                                      /* fails for simdjson */
-	//	{"-012345", -12345, nil},                                    /* fails for simdjson */
-	{"98765432100", 98765432100, nil},
-	{"-98765432100", -98765432100, nil},
-	{"9223372036854775807", 1<<63 - 1, nil},
-	{"-9223372036854775807", -(1<<63 - 1), nil},
-	{"9223372036854775808", 1<<63 - 1, strconv.ErrRange},
-	{"-9223372036854775808", -1 << 63, nil},
-	{"9223372036854775809", 1<<63 - 1, strconv.ErrRange},
-	{"-9223372036854775809", -1 << 63, strconv.ErrRange},
-	{"-1_2_3_4_5", 0, strconv.ErrSyntax}, // base=10 so no underscores allowed
-	{"-_12345", 0, strconv.ErrSyntax},
-	{"_12345", 0, strconv.ErrSyntax},
-	{"1__2345", 0, strconv.ErrSyntax},
-	{"12345_", 0, strconv.ErrSyntax},
+	{"", 0, TagEnd},
+	{"0", 0, TagInteger},
+	{"-0", 0, TagInteger},
+	{"1", 1, TagInteger},
+	{"-1", -1, TagInteger},
+	{"12345", 12345, TagInteger},
+	{"-12345", -12345, TagInteger},
+	{"012345", 0, TagEnd},
+	{"-012345", 0, TagEnd},
+	{"98765432100", 98765432100, TagInteger},
+	{"-98765432100", -98765432100, TagInteger},
+	{"9223372036854775807", 1<<63 - 1, TagInteger},
+	{"-9223372036854775807", -(1<<63 - 1), TagInteger},
+	{"9223372036854775808", 1<<63 - 1, TagUint},
+	{"-9223372036854775808", -1 << 63, TagInteger},
+	{"9223372036854775809", 1<<63 - 1, TagUint},
+	{"-9223372036854775809", -1 << 63, TagFloat},
+	{"-1_2_3_4_5", 0, TagEnd}, // base=10 so no underscores allowed
+	{"-_12345", 0, TagEnd},
+	{"_12345", 0, TagEnd},
+	{"1__2345", 0, TagEnd},
+	{"12345_", 0, TagEnd},
 
 	// zero (originate from atof tests below, but returned as int for simdjson)
-	{"0e0", 0, nil},
-	{"-0e0", 0, nil},
-	{"0e-0", 0, nil},
-	{"-0e-0", 0, nil},
-	{"0e+0", 0, nil},
-	{"-0e+0", 0, nil},
+	{"0e0", 0, TagFloat},
+	{"-0e0", 0, TagFloat},
+	{"0e-0", 0, TagFloat},
+	{"-0e-0", 0, TagFloat},
+	{"0e+0", 0, TagFloat},
+	{"-0e+0", 0, TagFloat},
+}
+
+func TestParseInt64(t *testing.T) {
+	for i := range parseInt64Tests {
+		test := &parseInt64Tests[i]
+		t.Run(test.in, func(t *testing.T) {
+
+			tag, val := parseNumber([]byte(fmt.Sprintf(`%s:`, test.in)))
+			if tag != test.tag {
+				// Ignore intentionally bad syntactical errors
+				t.Errorf("TestParseInt64: got: %v want: %v", tag, test.tag)
+				return // skip testing the rest for this test case
+			}
+			if tag == TagInteger && int64(val) != test.out {
+				// Ignore intentionally wrong conversions
+				t.Errorf("TestParseInt64: got value: %v want: %v", int64(val), test.out)
+			}
+		})
+
+	}
 }
 
 // The following code is borrowed from Golang (https://golang.org/src/strconv/atof_test.go)
@@ -321,59 +269,58 @@ type atofTest struct {
 }
 
 var atoftests = []atofTest{
-	//	{"", "0", strconv.ErrSyntax},                                /* fails for simdjson */
-	//	{"1", "1", nil},                                             /* parsed as int for simdjson */
-	//	{"+1", "1", nil},                                            /* parsed as int for simdjson */
+	{"", "0", strconv.ErrSyntax}, /* fails for simdjson */
+	{"1", "1", nil},              /* parsed as int for simdjson */
+	{"+1", "1", nil},             /* parsed as int for simdjson */
+
 	{"1x", "0", strconv.ErrSyntax},
 	{"1.1.", "0", strconv.ErrSyntax},
 	{"1e23", "1e+23", nil},
 	{"1E23", "1e+23", nil},
-	//	{"100000000000000000000000", "1e+23", nil},                  /* parsed as int for simdjson */
+	{"100000000000000000000000", "1e+23", nil}, /* parsed as int for simdjson */
 	{"1e-100", "1e-100", nil},
-	//	{"123456700", "1.234567e+08", nil},                          /* parsed as int for simdjson */
-	//	{"99999999999999974834176", "9.999999999999997e+22", nil},   /* parsed as int for simdjson */
-	//	{"100000000000000000000001", "1.0000000000000001e+23", nil}, /* parsed as int for simdjson */
-	//	{"100000000000000008388608", "1.0000000000000001e+23", nil}, /* parsed as int for simdjson */
-	//	{"100000000000000016777215", "1.0000000000000001e+23", nil}, /* parsed as int for simdjson */
-	//	{"100000000000000016777216", "1.0000000000000003e+23", nil}, /* parsed as int for simdjson */
-	//	{"-1", "-1", nil},                                           /* parsed as int for simdjson */
+	{"123456700", "123456700", nil},                             /* parsed as int for simdjson */
+	{"99999999999999974834176", "9.999999999999997e+22", nil},   /* parsed as int for simdjson */
+	{"100000000000000000000001", "1.0000000000000001e+23", nil}, /* parsed as int for simdjson */
+	{"100000000000000008388608", "1.0000000000000001e+23", nil}, /* parsed as int for simdjson */
+	{"100000000000000016777215", "1.0000000000000001e+23", nil}, /* parsed as int for simdjson */
+	{"100000000000000016777216", "1.0000000000000003e+23", nil}, /* parsed as int for simdjson */
+	{"-1", "-1", nil},                                           /* parsed as int for simdjson */
 	{"-0.1", "-0.1", nil},
-	//	{"-0", "-0", nil},                                           /* parsed as int for simdjson */
+	{"-0", "0", nil}, /* parsed as int for simdjson */
 	{"1e-20", "1e-20", nil},
 	{"625e-3", "0.625", nil},
 
-	// Hexadecimal floating-point.                               /* all fail for simdjson */
-
 	// zeros (several test cases for zero have been moved up because they are detected as ints)
-	//	{"+0e0", "0", nil},                                          /* fails for simdjson */
-	//	{"+0e-0", "0", nil},                                         /* fails for simdjson */
-	//	{"+0e+0", "0", nil},                                         /* fails for simdjson */
-	//	{"0e+01234567890123456789", "0", nil},                       /* fails for simdjson */
-	//	{"0.00e-01234567890123456789", "0", nil},                    /* fails for simdjson */
-	//	{"-0e+01234567890123456789", "-0", nil},                     /* fails for simdjson */
-	//	{"-0.00e-01234567890123456789", "-0", nil},                  /* fails for simdjson */
+	{"+0e0", "0", nil},
+	{"+0e-0", "0", nil},
+	{"+0e+0", "0", nil},
+	{"0e+01234567890123456789", "0", nil},
+	{"0.00e-01234567890123456789", "0", nil},
+	{"-0e+01234567890123456789", "-0", nil},
+	{"-0.00e-01234567890123456789", "-0", nil},
 
-	{"0e291", "0", nil}, // issue 15364
-	{"0e292", "0", nil}, // issue 15364
-	{"0e347", "0", nil}, // issue 15364
-	{"0e348", "0", nil}, // issue 15364
-	//	{"-0e291", "-0", nil},                                       /* returns "0" */
-	//	{"-0e292", "-0", nil},                                       /* returns "0" */
-	//	{"-0e347", "-0", nil},                                       /* returns "0" */
-	//	{"-0e348", "-0", nil},                                       /* returns "0" */
+	{"0e291", "0", nil},   // issue 15364
+	{"0e292", "0", nil},   // issue 15364
+	{"0e347", "0", nil},   // issue 15364
+	{"0e348", "0", nil},   // issue 15364
+	{"-0e291", "-0", nil}, /* returns "0" */
+	{"-0e292", "-0", nil}, /* returns "0" */
+	{"-0e347", "-0", nil}, /* returns "0" */
+	{"-0e348", "-0", nil}, /* returns "0" */
 
 	// NaNs
-	//	{"nan", "NaN", nil},                                         /* fails for simdjson */
-	//	{"NaN", "NaN", nil},                                         /* fails for simdjson */
-	//	{"NAN", "NaN", nil},                                         /* fails for simdjson */
+	{"nan", "NaN", errors.New("invalid json")},
+	{"NaN", "NaN", errors.New("invalid json")},
+	{"NAN", "NaN", errors.New("invalid json")},
 
 	// Infs
-	//	{"inf", "+Inf", nil},                                        /* fails for simdjson */
-	//	{"-Inf", "-Inf", nil},                                       /* fails for simdjson */
-	//	{"+INF", "+Inf", nil},                                       /* fails for simdjson */
-	//	{"-Infinity", "-Inf", nil},                                  /* fails for simdjson */
-	//	{"+INFINITY", "+Inf", nil},                                  /* fails for simdjson */
-	//	{"Infinity", "+Inf", nil},                                   /* fails for simdjson */
+	{"inf", "+Inf", errors.New("invalid json")},
+	{"-Inf", "-Inf", errors.New("invalid json")},
+	{"+INF", "+Inf", errors.New("invalid json")},
+	{"-Infinity", "-Inf", errors.New("invalid json")},
+	{"+INFINITY", "+Inf", errors.New("invalid json")},
+	{"Infinity", "+Inf", errors.New("invalid json")},
 
 	// largest float64
 	{"1.7976931348623157e308", "1.7976931348623157e+308", nil},
@@ -383,10 +330,8 @@ var atoftests = []atofTest{
 	{"1.7976931348623159e308", "+Inf", strconv.ErrRange},
 	{"-1.7976931348623159e308", "-Inf", strconv.ErrRange},
 
-	// the border is ...158079
-	// borderline - okay
-	//	{"1.7976931348623158e308", "1.7976931348623157e+308", nil},  /* returns "+Inf" */
-	//	{"-1.7976931348623158e308", "-1.7976931348623157e+308", nil},/* returns "-Inf" */
+	{"1.7976931348623158e308", "1.7976931348623157e+308", nil},
+	{"-1.7976931348623158e308", "-1.7976931348623157e+308", nil},
 
 	// borderline - too large
 	{"1.797693134862315808e308", "+Inf", strconv.ErrRange},
@@ -395,39 +340,39 @@ var atoftests = []atofTest{
 	// a little too large
 	{"1e308", "1e+308", nil},
 	{"2e308", "+Inf", strconv.ErrRange},
-	//	{"1e309", "+Inf", strconv.ErrRange},                         /* fails for simdjson */
+	{"1e309", "+Inf", strconv.ErrRange},
 
 	// way too large
-	//	{"1e310", "+Inf", strconv.ErrRange},                         /* fails for simdjson */
-	//	{"-1e310", "-Inf", strconv.ErrRange},                        /* fails for simdjson */
-	//	{"1e400", "+Inf", strconv.ErrRange},                         /* fails for simdjson */
-	//	{"-1e400", "-Inf", strconv.ErrRange},                        /* fails for simdjson */
-	//	{"1e400000", "+Inf", strconv.ErrRange},                      /* fails for simdjson */
-	//	{"-1e400000", "-Inf", strconv.ErrRange},                     /* fails for simdjson */
+	{"1e310", "+Inf", strconv.ErrRange},
+	{"-1e310", "-Inf", strconv.ErrRange},
+	{"1e400", "+Inf", strconv.ErrRange},
+	{"-1e400", "-Inf", strconv.ErrRange},
+	{"1e400000", "+Inf", strconv.ErrRange},
+	{"-1e400000", "-Inf", strconv.ErrRange},
 
 	// denormalized
 	{"1e-305", "1e-305", nil},
 	{"1e-306", "1e-306", nil},
 	{"1e-307", "1e-307", nil},
 	{"1e-308", "1e-308", nil},
-	//	{"1e-309", "1e-309", nil},                                   /* fails for simdjson */
-	//	{"1e-310", "1e-310", nil},                                   /* fails for simdjson */
-	//	{"1e-322", "1e-322", nil},                                   /* fails for simdjson */
+	{"1e-309", "1e-309", nil},
+	{"1e-310", "1e-310", nil},
+	{"1e-322", "1e-322", nil},
 	// smallest denormal
-	//	{"5e-324", "5e-324", nil},                                   /* fails for simdjson */
-	//	{"4e-324", "5e-324", nil},                                   /* fails for simdjson */
-	//	{"3e-324", "5e-324", nil},                                   /* fails for simdjson */
+	{"5e-324", "5e-324", nil},
+	{"4e-324", "5e-324", nil},
+	{"3e-324", "5e-324", nil},
 	// too small
-	//	{"2e-324", "0", nil},                                        /* fails for simdjson */
+	{"2e-324", "0", nil},
 	// way too small
-	//	{"1e-350", "0", nil},                                        /* fails for simdjson */
-	//	{"1e-400000", "0", nil},                                     /* fails for simdjson */
+	{"1e-350", "0", nil},
+	{"1e-400000", "0", nil},
 
 	// try to overflow exponent
-	//	{"1e-4294967296", "0", nil},                                 /* fails for simdjson */
-	//	{"1e+4294967296", "+Inf", strconv.ErrRange},                 /* fails for simdjson */
-	//	{"1e-18446744073709551616", "0", nil},                       /* fails for simdjson */
-	//	{"1e+18446744073709551616", "+Inf", strconv.ErrRange},       /* fails for simdjson */
+	{"1e-4294967296", "0", nil},
+	{"1e+4294967296", "+Inf", strconv.ErrRange},
+	{"1e-18446744073709551616", "0", nil},
+	{"1e+18446744073709551616", "+Inf", strconv.ErrRange},
 
 	// Parse errors
 	{"1e", "0", strconv.ErrSyntax},
@@ -435,33 +380,33 @@ var atoftests = []atofTest{
 	{".e-1", "0", strconv.ErrSyntax},
 
 	// https://www.exploringbinary.com/java-hangs-when-converting-2-2250738585072012e-308/
-	//	{"2.2250738585072012e-308", "2.2250738585072014e-308", nil}, /* fails for simdjson */
+	{"2.2250738585072012e-308", "2.2250738585072014e-308", nil},
 	// https://www.exploringbinary.com/php-hangs-on-numeric-value-2-2250738585072011e-308/
-	//	{"2.2250738585072011e-308", "2.225073858507201e-308", nil},  /* fails for simdjson */
+	{"2.2250738585072011e-308", "2.225073858507201e-308", nil},
 
 	// A very large number (initially wrongly parsed by the fast algorithm).
-	//	{"4.630813248087435e+307", "4.630813248087435e+307", nil},   /* fails for simdjson */
+	{"4.630813248087435e+307", "4.630813248087435e+307", nil},
 
 	// A different kind of very large number.
-	//	{"22.222222222222222", "22.22222222222222", nil},            /* fails for simdjson */
-	//	{"2." + strings.Repeat("2", 4000) + "e+1", "22.22222222222222", nil},
+	{"22.222222222222222", "22.22222222222222", nil},
+	{"2." + strings.Repeat("2", 4000) + "e+1", "22.22222222222222", nil},
 
 	// Exactly halfway between 1 and math.Nextafter(1, 2).
 	// Round to even (down).
-	//	{"1.00000000000000011102230246251565404236316680908203125", "1", nil}, /* fails for simdjson */
+	{"1.00000000000000011102230246251565404236316680908203125", "1", nil},
 	// Slightly lower; still round down.
-	//	{"1.00000000000000011102230246251565404236316680908203124", "1", nil}, /* fails for simdjson */
+	{"1.00000000000000011102230246251565404236316680908203124", "1", nil},
 	// Slightly higher; round up.
-	//	{"1.00000000000000011102230246251565404236316680908203126", "1.0000000000000002", nil}, /* fails for simdjson */
+	{"1.00000000000000011102230246251565404236316680908203126", "1.0000000000000002", nil},
 	// Slightly higher, but you have to read all the way to the end.
-	//	{"1.00000000000000011102230246251565404236316680908203125" + strings.Repeat("0", 10000) + "1", "1.0000000000000002", nil},  /* fails for simdjson */
+	{"1.00000000000000011102230246251565404236316680908203125" + strings.Repeat("0", 10000) + "1", "1.0000000000000002", nil},
 
 	// Halfway between x := math.Nextafter(1, 2) and math.Nextafter(x, 2)
 	// Round to even (up).
-	//	{"1.00000000000000033306690738754696212708950042724609375", "1.0000000000000004", nil}, /* fails for simdjson */
+	{"1.00000000000000033306690738754696212708950042724609375", "1.0000000000000004", nil},
 
 	// Underscores.
-	//	{"1_23.50_0_0e+1_2", "1.235e+14", nil},                      /* fails for simdjson */
+	{"1_23.50_0_0e+1_2", "1.235e+14", strconv.ErrSyntax},
 	{"-_123.5e+12", "0", strconv.ErrSyntax},
 	{"+_123.5e+12", "0", strconv.ErrSyntax},
 	{"_123.5e+12", "0", strconv.ErrSyntax},
@@ -476,6 +421,41 @@ var atoftests = []atofTest{
 	{"123.5e-_12", "0", strconv.ErrSyntax},
 	{"123.5e+1__2", "0", strconv.ErrSyntax},
 	{"123.5e+12_", "0", strconv.ErrSyntax},
+}
+
+func TestParseFloat64(t *testing.T) {
+
+	for i := 0; i < len(atoftests); i++ {
+		test := &atoftests[i]
+		t.Run(test.in, func(t *testing.T) {
+			tag, val := parseNumber([]byte(fmt.Sprintf(`%s:`, test.in)))
+			switch tag {
+			case TagEnd:
+				if test.err == nil {
+					t.Errorf("TestParseFloat64: got error, none")
+				}
+			case TagFloat:
+				got := math.Float64frombits(val)
+				outs := strconv.FormatFloat(got, 'g', -1, 64)
+				if outs != test.out {
+					t.Errorf("TestParseFloat64: got: %v want: %v", outs, test.out)
+				}
+			case TagInteger:
+				got := int64(val)
+				outs := fmt.Sprint(got)
+				if outs != test.out {
+					t.Errorf("TestParseFloat64: got: %v want: %v", outs, test.out)
+				}
+			case TagUint:
+				got := val
+				outs := fmt.Sprint(got)
+				if outs != test.out {
+					t.Errorf("TestParseFloat64: got: %v want: %v", outs, test.out)
+				}
+			default:
+			}
+		})
+	}
 }
 
 func TestParseString(t *testing.T) {
@@ -562,13 +542,8 @@ func benchmarkParseNumber(b *testing.B, neg int) {
 		b.Run(cs.name, func(b *testing.B) {
 			s := fmt.Sprintf("%d", cs.num*int64(neg))
 			s = fmt.Sprintf(`%s:`, s) // append delimiter
-			found_minus := false
-			if neg != 0 {
-				found_minus = true
-			}
 			for i := 0; i < b.N; i++ {
-				_, _, _, i := parse_number_simd([]byte(s), found_minus)
-				BenchSink += int(i)
+				parseNumber([]byte(s))
 			}
 		})
 	}
@@ -576,7 +551,7 @@ func benchmarkParseNumber(b *testing.B, neg int) {
 
 func BenchmarkParseNumberFloat(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		parse_number_simd([]byte("339.7784:"), false)
+		parseNumber([]byte("339.7784:"))
 	}
 }
 
@@ -588,27 +563,27 @@ func BenchmarkParseAtof64FloatGolang(b *testing.B) {
 
 func BenchmarkParseNumberFloatExp(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		parse_number_simd([]byte("-5.09e75:"), false)
+		parseNumber([]byte("-5.09e75:"))
 	}
 }
 
 func BenchmarkParseNumberBig(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		parse_number_simd([]byte("123456789123456789123456789:"), false)
+		parseNumber([]byte("123456789123456789123456789:"))
 	}
 }
 
 func BenchmarkParseNumberRandomBits(b *testing.B) {
 	initAtof()
 	for i := 0; i < b.N; i++ {
-		parse_number_simd([]byte(benchmarksRandomBitsSimd[i%1024]), false)
+		parseNumber([]byte(benchmarksRandomBitsSimd[i%1024]))
 	}
 }
 
 func BenchmarkParseNumberRandomFloats(b *testing.B) {
 	initAtof()
 	for i := 0; i < b.N; i++ {
-		parse_number_simd([]byte(benchmarksRandomNormalSimd[i%1024]), false)
+		parseNumber([]byte(benchmarksRandomNormalSimd[i%1024]))
 	}
 }
 

--- a/parse_number_amd64.go
+++ b/parse_number_amd64.go
@@ -21,43 +21,106 @@
 package simdjson
 
 import (
+	"math"
 	"strconv"
-	"unicode"
-	"unsafe"
 )
 
-//go:noescape
-func _parse_number(buf unsafe.Pointer, offset, found_minus uint64, is_double, resultDouble, resultInt64 unsafe.Pointer) (success uint64)
+const (
+	isPartOfNumberFlag = 1 << iota
+	isFloatOnlyFlag
+	isMinusFlag
+	isEOVFlag
+	isDigitFlag
+	isMustHaveDigitNext
+)
 
-func parse_number_simd(buf []byte, found_minus bool) (success, is_double bool, d float64, i int) {
+var isNumberRune = [256]uint8{
+	'0':  isPartOfNumberFlag | isDigitFlag,
+	'1':  isPartOfNumberFlag | isDigitFlag,
+	'2':  isPartOfNumberFlag | isDigitFlag,
+	'3':  isPartOfNumberFlag | isDigitFlag,
+	'4':  isPartOfNumberFlag | isDigitFlag,
+	'5':  isPartOfNumberFlag | isDigitFlag,
+	'6':  isPartOfNumberFlag | isDigitFlag,
+	'7':  isPartOfNumberFlag | isDigitFlag,
+	'8':  isPartOfNumberFlag | isDigitFlag,
+	'9':  isPartOfNumberFlag | isDigitFlag,
+	'.':  isPartOfNumberFlag | isFloatOnlyFlag | isMustHaveDigitNext,
+	'+':  isPartOfNumberFlag,
+	'-':  isPartOfNumberFlag | isMinusFlag | isMustHaveDigitNext,
+	'e':  isPartOfNumberFlag | isFloatOnlyFlag,
+	'E':  isPartOfNumberFlag | isFloatOnlyFlag,
+	',':  isEOVFlag,
+	'}':  isEOVFlag,
+	']':  isEOVFlag,
+	' ':  isEOVFlag,
+	'\t': isEOVFlag,
+	'\r': isEOVFlag,
+	'\n': isEOVFlag,
+	':':  isEOVFlag,
+}
 
-	if GOLANG_NUMBER_PARSING {
-
-		pos := 0
-		for ; pos < len(buf) && (unicode.IsDigit(rune(buf[pos])) || buf[pos] == '.' || buf[pos] == '+' || buf[pos] == '-' || buf[pos] == 'e' || buf[pos] == 'E'); pos++ {
+// parseNumber will parse the number starting in the buffer.
+// Any non-number characters at the end will be ignored.
+// Returns TagEnd if no valid value found be found.
+func parseNumber(buf []byte) (tag Tag, val uint64) {
+	pos := 0
+	found := uint8(0)
+	for i, v := range buf {
+		t := isNumberRune[v]
+		if t == 0 {
+			//fmt.Println("aborting on", string(v), "in", string(buf[:i]))
+			return TagEnd, 0
 		}
+		if t == isEOVFlag {
+			break
+		}
+		if t&isMustHaveDigitNext > 0 {
+			// A period and minus must be followed by a digit
+			if len(buf) < i+2 || isNumberRune[buf[i+1]]&isDigitFlag == 0 {
+				return TagEnd, 0
+			}
+		}
+		found |= t
+		pos = i + 1
+	}
+	if pos == 0 {
+		return TagEnd, 0
+	}
+	const maxIntLen = 20
 
-		var err error
-		i, err = strconv.Atoi(string(buf[:pos]))
+	// Only try integers if we didn't find any float exclusive and it can fit in an integer.
+	if found&isFloatOnlyFlag == 0 && pos <= 20 {
+		if found&isMinusFlag == 0 {
+			if pos > 1 && buf[0] == '0' {
+				// Integers cannot have a leading zero.
+				return TagEnd, 0
+			}
+		} else {
+			if pos > 2 && buf[1] == '0' {
+				// Integers cannot have a leading zero after minus.
+				return TagEnd, 0
+			}
+		}
+		i64, err := strconv.ParseInt(string(buf[:pos]), 10, 64)
 		if err == nil {
-			success = true
-			return
+			return TagInteger, uint64(i64)
 		}
-		d, err = strconv.ParseFloat(string(buf[:pos]), 64)
-		if err == nil {
-			success, is_double = true, true
+		if found&isMinusFlag == 0 {
+			u64, err := strconv.ParseUint(string(buf[:pos]), 10, 64)
+			if err == nil {
+				return TagUint, u64
+			}
 		}
-		return
 	}
 
-	src := uintptr(unsafe.Pointer(&buf[0]))
-
-	fm := uint64(0)
-	if found_minus {
-		fm = 1
+	if pos > 1 && buf[0] == '0' && isNumberRune[buf[1]]&isFloatOnlyFlag == 0 {
+		// Float can only have have a leading 0 when followed by a period.
+		return TagEnd, 0
 	}
-
-	success = _parse_number(unsafe.Pointer(src), 0, fm, unsafe.Pointer(&is_double), unsafe.Pointer(&d), unsafe.Pointer(&i)) != 0
-
-	return
+	f64, err := strconv.ParseFloat(string(buf[:pos]), 64)
+	if err == nil {
+		return TagFloat, math.Float64bits(f64)
+	}
+	return TagEnd, 0
 }

--- a/parsed_json_test.go
+++ b/parsed_json_test.go
@@ -148,7 +148,7 @@ func testCTapeCtoGoTapeCompare(t *testing.T, ctape []uint64, csbuf []byte, pj in
 
 		case TagInteger, TagFloat:
 			if ctape[cindex+1] != gotape[goindex+1] {
-				if !(ntype == TagFloat && GOLANG_NUMBER_PARSING) {
+				if ntype != TagFloat {
 					t.Errorf("TestCTapeCtoGoTapeCompare: got: %016x want: %016x", gotape[goindex+1], ctape[cindex+1])
 
 				}

--- a/simdjson_amd64.go
+++ b/simdjson_amd64.go
@@ -29,13 +29,12 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/klauspost/cpuid"
+	"github.com/klauspost/cpuid/v2"
 )
 
 // SupportedCPU will return whether the CPU is supported.
 func SupportedCPU() bool {
-	const want = cpuid.AVX2 | cpuid.CLMUL
-	return cpuid.CPU.Features&want == want
+	return cpuid.CPU.Supports(cpuid.AVX2, cpuid.CLMUL)
 }
 
 // Parse a block of data and return the parsed JSON.

--- a/simdjson_amd64_test.go
+++ b/simdjson_amd64_test.go
@@ -87,9 +87,6 @@ func TestParseND(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.skipFloats && GOLANG_NUMBER_PARSING {
-				return
-			}
 			got, err := ParseND([]byte(tt.js), nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseND() error = %v, wantErr %v", err, tt.wantErr)
@@ -169,11 +166,10 @@ func TestParseFailCases(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		skipFloats bool // Skip tests that contain float64 inprecisions (see GOLANG_NUMBER_PARSING flag)
-		js         string
-		want       string
-		wantErr    bool
+		name    string
+		js      string
+		want    string
+		wantErr bool
 	}{
 		{
 			name:    "fail01_EXCLUDE",
@@ -236,16 +232,14 @@ func TestParseFailCases(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:       "fail13",
-			skipFloats: true,
-			js:         `{"Numbers cannot have leading zeroes": 013}`,
-			wantErr:    true,
+			name:    "fail13",
+			js:      `{"Numbers cannot have leading zeroes": 013}`,
+			wantErr: true,
 		},
 		{
-			name:       "fail14",
-			skipFloats: true,
-			js:         `{"Numbers cannot be hex": 0x14}`,
-			wantErr:    true,
+			name:    "fail14",
+			js:      `{"Numbers cannot be hex": 0x14}`,
+			wantErr: true,
 		},
 		{
 			name:    "fail15",
@@ -351,10 +345,9 @@ break"]`,
 			wantErr: true,
 		},
 		{
-			name:       "fail37",
-			skipFloats: true,
-			js:         `[12a]`,
-			wantErr:    true,
+			name:    "fail37",
+			js:      `[12a]`,
+			wantErr: true,
 		},
 		{
 			name:    "fail38",
@@ -384,46 +377,39 @@ break"]`,
 			wantErr: true,
 		},
 		{
-			name:       "fail44",
-			skipFloats: true,
-			js:         `[-2.]`,
-			wantErr:    true,
+			name:    "fail44",
+			js:      `[-2.]`,
+			wantErr: true,
 		},
 		{
-			name:       "fail45",
-			skipFloats: true,
-			js:         `[0.e1]`,
-			wantErr:    true,
+			name:    "fail45",
+			js:      `[0.e1]`,
+			wantErr: true,
 		},
 		{
-			name:       "fail46",
-			skipFloats: true,
-			js:         `[2.e+3]`,
-			wantErr:    true,
+			name:    "fail46",
+			js:      `[2.e+3]`,
+			wantErr: true,
 		},
 		{
-			name:       "fail47",
-			skipFloats: true,
-			js:         `[2.e-3]`,
-			wantErr:    true,
+			name:    "fail47",
+			js:      `[2.e-3]`,
+			wantErr: true,
 		},
 		{
-			name:       "fail48",
-			skipFloats: true,
-			js:         `[2.e3]`,
-			wantErr:    true,
+			name:    "fail48",
+			js:      `[2.e3]`,
+			wantErr: true,
 		},
 		{
-			name:       "fail49",
-			skipFloats: true,
-			js:         `[-.123]`,
-			wantErr:    true,
+			name:    "fail49",
+			js:      `[-.123]`,
+			wantErr: true,
 		},
 		{
-			name:       "fail50",
-			skipFloats: true,
-			js:         `[1.]`,
-			wantErr:    true,
+			name:    "fail50",
+			js:      `[1.]`,
+			wantErr: true,
 		},
 		{
 			name:    "fail51",
@@ -653,9 +639,6 @@ break"]`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.skipFloats && GOLANG_NUMBER_PARSING {
-				return
-			}
 			got, err := Parse([]byte(tt.js), nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseFailCases() error = %v, wantErr %v", err, tt.wantErr)
@@ -977,9 +960,6 @@ func TestParsePassCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.skipFloats {
-				return
-			}
-			if tt.onlyPrecise && !GOLANG_NUMBER_PARSING {
 				return
 			}
 			var err error

--- a/stage1_find_marks_amd64.go
+++ b/stage1_find_marks_amd64.go
@@ -23,7 +23,7 @@ package simdjson
 import (
 	"sync/atomic"
 
-	"github.com/klauspost/cpuid"
+	"github.com/klauspost/cpuid/v2"
 )
 
 func json_markup(b byte) bool {
@@ -33,7 +33,7 @@ func json_markup(b byte) bool {
 func find_structural_indices(buf []byte, pj *internalParsedJson) bool {
 
 	f := find_structural_bits_in_slice
-	if cpuid.CPU.AVX512F() {
+	if cpuid.CPU.Has(cpuid.AVX512F) {
 		f = find_structural_bits_in_slice_avx512
 	}
 

--- a/stage2_build_tape_amd64_test.go
+++ b/stage2_build_tape_amd64_test.go
@@ -26,13 +26,8 @@ import (
 
 func TestStage2BuildTape(t *testing.T) {
 
-	floatHexRepresentation1 := uint64(0x69066666666667)
-	floatHexRepresentation2 := uint64(0x79066666666667)
-
-	if GOLANG_NUMBER_PARSING {
-		floatHexRepresentation1 = 0x69066666666666
-		floatHexRepresentation2 = 0x79066666666666
-	}
+	var floatHexRepresentation1 uint64 = 0x69066666666666
+	var floatHexRepresentation2 uint64 = 0x79066666666666
 
 	const nul = '\000'
 


### PR DESCRIPTION
Remove `GOLANG_NUMBER_PARSING` and remove the imprecise parsing and fix up the actual number parsing in Go.

By default, everything that looked like a number would be accepted and a lot of errors were not caught.

Uints will now actually be used if numbers are above maximum int64 and below uint64 with no float point markers.

Even with all the additional checks we are still faster:

```
λ benchcmp before.txt after.txt
benchmark                               old ns/op     new ns/op     delta
BenchmarkParseNumber/Pos/63bit-32       91.9          75.9          -17.41%
BenchmarkParseNumber/Neg/63bit-32       106           77.2          -27.17%
BenchmarkParseNumberFloat-32            190           72.5          -61.84%
BenchmarkParseNumberFloatExp-32         212           98.6          -53.49%
BenchmarkParseNumberBig-32              401           175           -56.36%
BenchmarkParseNumberRandomBits-32       420           230           -45.24%
BenchmarkParseNumberRandomFloats-32     305           172           -43.61%
```