### PR TITLE
Indicate float conversion due to overflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,28 @@ method to get an iterator.
 There are methods that allow you to retrieve all elements as a single type, 
 []int64, []uint64, float64 and strings.  
 
+## Number parsing
+
+Numbers in JSON are untyped and are returned by the following rules in order:
+
+* If there is any float point notation, like exponents, or a dot notation, it is always returned as float.
+* If number is a pure integer and it fits within an int64 it is returned as such.
+* If number is a pure positive integer and fits within a uint64 it is returned as such.
+* If the number is valid number it is returned as float64.
+
+If the number was converted from integer notation to a float due to not fitting inside int64/uint64
+the `FloatOverflowedInteger` flag is set, which can be retrieved using `(Iter).FloatFlags()` method.  
+
+JSON numbers follow JavaScript’s double-precision floating-point format.
+
+* Represented in base 10 with no superfluous leading zeros (e.g. 67, 1, 100).
+* Include digits between 0 and 9.
+* Can be a negative number (e.g. -10).
+* Can be a fraction (e.g. .5).
+* Can also have an exponent of 10, prefixed by e or E with a plus or minus sign to indicate positive or negative exponentiation.
+* Octal and hexadecimal formats are not supported.
+* Can not have a value of NaN (Not A Number) or Infinity.
+
 ## Parsing NDSJON stream
 
 Newline delimited json is sent as packets with each line being a root element.

--- a/parse_json_amd64.go
+++ b/parse_json_amd64.go
@@ -42,10 +42,10 @@ func (pj *internalParsedJson) initialize(size int) {
 		pj.Strings = make([]byte, 0, stringsSize)
 	}
 	pj.Strings = pj.Strings[:0]
-	if cap(pj.containing_scope_offset) < maxdepth {
-		pj.containing_scope_offset = make([]uint64, 0, maxdepth)
+	if cap(pj.containingScopeOffset) < maxdepth {
+		pj.containingScopeOffset = make([]uint64, 0, maxdepth)
 	}
-	pj.containing_scope_offset = pj.containing_scope_offset[:0]
+	pj.containingScopeOffset = pj.containingScopeOffset[:0]
 }
 
 func (pj *internalParsedJson) parseMessage(msg []byte) error {
@@ -75,8 +75,8 @@ func (pj *internalParsedJson) parseMessageInternal(msg []byte, ndjson bool) (err
 	// Make the capacity of the channel smaller than the number of slots.
 	// This way the sender will automatically block until the consumer
 	// has finished the slot it is working on.
-	pj.index_chan = make(chan indexChan, indexSlots-2)
-	pj.buffers_offset = ^uint64(0)
+	pj.indexChans = make(chan indexChan, indexSlots-2)
+	pj.buffersOffset = ^uint64(0)
 
 	var errStage1 error
 	go func() {
@@ -89,7 +89,7 @@ func (pj *internalParsedJson) parseMessageInternal(msg []byte, ndjson bool) (err
 		if !unifiedMachine(pj.Message, pj) {
 			err = errors.New("Bad parsing while executing stage 2")
 			// drain the channel until empty
-			for range pj.index_chan {
+			for range pj.indexChans {
 			}
 		}
 		wg.Done()

--- a/parse_number_amd64.go
+++ b/parse_number_amd64.go
@@ -21,6 +21,7 @@
 package simdjson
 
 import (
+	"errors"
 	"math"
 	"strconv"
 )
@@ -63,14 +64,14 @@ var isNumberRune = [256]uint8{
 // parseNumber will parse the number starting in the buffer.
 // Any non-number characters at the end will be ignored.
 // Returns TagEnd if no valid value found be found.
-func parseNumber(buf []byte) (tag Tag, val uint64) {
+func parseNumber(buf []byte) (tag Tag, val, flags uint64) {
 	pos := 0
 	found := uint8(0)
 	for i, v := range buf {
 		t := isNumberRune[v]
 		if t == 0 {
 			//fmt.Println("aborting on", string(v), "in", string(buf[:i]))
-			return TagEnd, 0
+			return TagEnd, 0, 0
 		}
 		if t == isEOVFlag {
 			break
@@ -78,14 +79,14 @@ func parseNumber(buf []byte) (tag Tag, val uint64) {
 		if t&isMustHaveDigitNext > 0 {
 			// A period and minus must be followed by a digit
 			if len(buf) < i+2 || isNumberRune[buf[i+1]]&isDigitFlag == 0 {
-				return TagEnd, 0
+				return TagEnd, 0, 0
 			}
 		}
 		found |= t
 		pos = i + 1
 	}
 	if pos == 0 {
-		return TagEnd, 0
+		return TagEnd, 0, 0
 	}
 	const maxIntLen = 20
 
@@ -94,33 +95,42 @@ func parseNumber(buf []byte) (tag Tag, val uint64) {
 		if found&isMinusFlag == 0 {
 			if pos > 1 && buf[0] == '0' {
 				// Integers cannot have a leading zero.
-				return TagEnd, 0
+				return TagEnd, 0, 0
 			}
 		} else {
 			if pos > 2 && buf[1] == '0' {
 				// Integers cannot have a leading zero after minus.
-				return TagEnd, 0
+				return TagEnd, 0, 0
 			}
 		}
 		i64, err := strconv.ParseInt(string(buf[:pos]), 10, 64)
 		if err == nil {
-			return TagInteger, uint64(i64)
+			return TagInteger, uint64(i64), 0
 		}
+		if errors.Is(err, strconv.ErrRange) {
+			flags |= uint64(FloatOverflowedInteger)
+		}
+
 		if found&isMinusFlag == 0 {
 			u64, err := strconv.ParseUint(string(buf[:pos]), 10, 64)
 			if err == nil {
-				return TagUint, u64
+				return TagUint, u64, 0
+			}
+			if errors.Is(err, strconv.ErrRange) {
+				flags |= uint64(FloatOverflowedInteger)
 			}
 		}
+	} else if found&isFloatOnlyFlag == 0 {
+		flags |= uint64(FloatOverflowedInteger)
 	}
 
 	if pos > 1 && buf[0] == '0' && isNumberRune[buf[1]]&isFloatOnlyFlag == 0 {
 		// Float can only have have a leading 0 when followed by a period.
-		return TagEnd, 0
+		return TagEnd, 0, 0
 	}
 	f64, err := strconv.ParseFloat(string(buf[:pos]), 64)
 	if err == nil {
-		return TagFloat, math.Float64bits(f64)
+		return TagFloat, math.Float64bits(f64), flags
 	}
-	return TagEnd, 0
+	return TagEnd, 0, 0
 }

--- a/parse_number_test.go
+++ b/parse_number_test.go
@@ -31,7 +31,7 @@ func TestNumberIsValid(t *testing.T) {
 	// From: https://stackoverflow.com/a/13340826
 	var jsonNumberRegexp = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
 	isValidNumber := func(s string) bool {
-		tag, _ := parseNumber([]byte(s))
+		tag, _, _ := parseNumber([]byte(s))
 		return tag != TagEnd
 	}
 	validTests := []string{

--- a/parsed_serialize.go
+++ b/parsed_serialize.go
@@ -611,6 +611,8 @@ func (s *Serializer) Deserialize(src []byte, dst *ParsedJson) (*ParsedJson, erro
 			}
 			dst.Tape[off] = binary.LittleEndian.Uint64(values[:8])
 			dst.Tape[off+1] = binary.LittleEndian.Uint64(values[8:16])
+			values = values[16:]
+			off += 2
 		case TagNull, TagBoolTrue, TagBoolFalse, TagEnd:
 			dst.Tape[off] = tagDst
 			off++

--- a/parsed_serialize.go
+++ b/parsed_serialize.go
@@ -33,9 +33,10 @@ import (
 )
 
 const (
-	stringBits = 14
-	stringSize = 1 << stringBits
-	stringmask = stringSize - 1
+	stringBits        = 14
+	stringSize        = 1 << stringBits
+	stringmask        = stringSize - 1
+	serializedVersion = 2
 )
 
 // Serializer allows to serialize parsed json and read it back.
@@ -373,7 +374,7 @@ func (s *Serializer) Serialize(dst []byte, pj ParsedJson) []byte {
 	wg.Wait()
 
 	// Version
-	dst = append(dst, 1)
+	dst = append(dst, serializedVersion)
 
 	// Size of varints...
 	varInts := binary.PutUvarint(tmp[:], uint64(0)) +
@@ -463,7 +464,8 @@ func (s *Serializer) Deserialize(src []byte, dst *ParsedJson) (*ParsedJson, erro
 
 	if v, err := br.ReadByte(); err != nil {
 		return dst, err
-	} else if v != 1 {
+	} else if v > serializedVersion {
+		// v2 reads v1.
 		return dst, errors.New("unknown version")
 	}
 

--- a/parsed_serialize.go
+++ b/parsed_serialize.go
@@ -228,6 +228,7 @@ func (s *Serializer) Serialize(dst []byte, pj ParsedJson) []byte {
 	//   - TagObjectEnd, TagArrayEnd: No value stored, derived from start.
 	//   - TagInteger, TagUint, TagFloat: 64 bits
 	// 	 - TagString: offset, length stored.
+	//   - tagFloatWithFlag (v2): Contains float parsing flag.
 	//
 	// If there are any values left as tag or value, it is considered invalid.
 

--- a/stage1_find_marks_amd64.go
+++ b/stage1_find_marks_amd64.go
@@ -74,7 +74,7 @@ func findStructuralIndices(buf []byte, pj *internalParsedJson) bool {
 	for len(buf) > 0 {
 
 		index := indexChan{}
-		offset := atomic.AddUint64(&pj.buffers_offset, 1)
+		offset := atomic.AddUint64(&pj.buffersOffset, 1)
 		index.indexes = &pj.buffers[offset%indexSlots]
 
 		// In case last index during previous round was stripped back, put it back
@@ -125,13 +125,13 @@ func findStructuralIndices(buf []byte, pj *internalParsedJson) bool {
 			index.length -= 1
 		}
 
-		pj.index_chan <- index
+		pj.indexChans <- index
 		indexTotal += index.length
 
 		buf = buf[processed:]
 		position -= processed
 	}
-	close(pj.index_chan)
+	close(pj.indexChans)
 
 	// a valid JSON file cannot have zero structural indexes - we should have found something
 	return error_mask == 0 && indexTotal > 0

--- a/stage1_find_marks_amd64_test.go
+++ b/stage1_find_marks_amd64_test.go
@@ -138,13 +138,13 @@ func TestFindStructuralIndices(t *testing.T) {
 	}
 
 	pj := internalParsedJson{}
-	pj.index_chan = make(chan indexChan, 16)
+	pj.indexChans = make(chan indexChan, 16)
 
 	// No need to spawn go-routine since the channel is large enough
 	findStructuralIndices([]byte(demo_json), &pj)
 
 	ipos, pos := 0, ^uint64(0)
-	for ic := range pj.index_chan {
+	for ic := range pj.indexChans {
 		for j := 0; j < ic.length; j++ {
 			pos += uint64((*ic.indexes)[j])
 			result := fmt.Sprintf("%s%s", strings.Repeat(" ", int(pos)), demo_json[pos:])
@@ -168,7 +168,7 @@ func BenchmarkStage1(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Create new channel (large enough so we won't block)
-		pj.index_chan = make(chan indexChan, 128)
+		pj.indexChans = make(chan indexChan, 128)
 		findStructuralIndices([]byte(msg), &pj)
 	}
 }


### PR DESCRIPTION
As flag to tape that indicates that an integer was converted to float due to int64/uint64 limits.

Fixes #30