### PR TITLE
Avoid using BP register

### DIFF
--- a/find_odd_backslash_sequences_amd64.s
+++ b/find_odd_backslash_sequences_amd64.s
@@ -22,8 +22,8 @@ TEXT ·_find_odd_backslash_sequences(SB), $0-24
 	RET
 
 TEXT ·__find_odd_backslash_sequences(SB), $0
-	LEAQ      LCDATA1<>(SB), BP
-	VMOVDQA   (BP), Y0           // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
+	LEAQ      LCDATA1<>(SB), R8
+	VMOVDQA   (R8), Y0           // vmovdqa    ymm0, yword 0[rbp] /* [rip + LCPI0_0] */
 	VPCMPEQB  Y8/*(DI)*/, Y0, Y1 // vpcmpeqb    ymm1, ymm0, yword [rdi]
 	VPMOVMSKB Y1, CX             // vpmovmskb    ecx, ymm1
 	VPCMPEQB  Y9/*(SI)*/, Y0, Y0 // vpcmpeqb    ymm0, ymm0, yword [rsi]

--- a/find_quote_mask_and_bits_amd64.s
+++ b/find_quote_mask_and_bits_amd64.s
@@ -47,11 +47,11 @@ TEXT ·_find_quote_mask_and_bits(SB), $0-48
 	RET
 
 TEXT ·__find_quote_mask_and_bits(SB), $0
-	LEAQ LCDATA1<>(SB), BP
+	LEAQ LCDATA1<>(SB), R10
 
 	VMOVDQA    Y8, Y0         // vmovdqu    ymm0, yword [rdi]
 	VMOVDQA    Y9, Y1         // vmovdqu    ymm1, yword [rsi]
-	VMOVDQA    (BP), Y2       // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
+	VMOVDQA    (R10), Y2      // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
 	VPCMPEQB   Y2, Y0, Y3     // vpcmpeqb    ymm3, ymm0, ymm2
 	VPMOVMSKB  Y3, AX         // vpmovmskb    eax, ymm3
 	VPCMPEQB   Y2, Y1, Y2     // vpcmpeqb    ymm2, ymm1, ymm2
@@ -66,9 +66,9 @@ TEXT ·__find_quote_mask_and_bits(SB), $0
 	VPCLMULQDQ $0, X3, X2, X2 // vpclmulqdq    xmm2, xmm2, xmm3, 0
 	VMOVQ      X2, AX         // vmovq    rax, xmm2
 	XORQ       (CX), AX       // xor    rax, qword [rcx]
-	VMOVDQA    0x40(BP), Y2   // vmovdqa    ymm2, yword 32[rbp] /* [rip + LCPI0_1] */
+	VMOVDQA    0x40(R10), Y2  // vmovdqa    ymm2, yword 32[rbp] /* [rip + LCPI0_1] */
 	VPXOR      Y2, Y0, Y0     // vpxor    ymm0, ymm0, ymm2
-	VMOVDQA    0x80(BP), Y3   // vmovdqa    ymm3, yword 64[rbp] /* [rip + LCPI0_2] */
+	VMOVDQA    0x80(R10), Y3  // vmovdqa    ymm3, yword 64[rbp] /* [rip + LCPI0_2] */
 	VPCMPGTB   Y0, Y3, Y0     // vpcmpgtb    ymm0, ymm3, ymm0
 	VPMOVMSKB  Y0, DX         // vpmovmskb    edx, ymm0
 	VPXOR      Y2, Y1, Y0     // vpxor    ymm0, ymm1, ymm2
@@ -107,10 +107,10 @@ TEXT ·_find_quote_mask_and_bits_avx512(SB), $0-48
 #define QMAB_CONST3 Z19
 
 TEXT ·__init_quote_mask_and_bits_avx512(SB), $0
-	LEAQ      LCDATA1<>(SB), BP
-	VMOVDQU32 0x00(BP), QMAB_CONST1
-	VMOVDQU32 0x40(BP), QMAB_CONST2
-	VMOVDQU32 0x80(BP), QMAB_CONST3
+	LEAQ      LCDATA1<>(SB), R10
+	VMOVDQU32 0x00(R10), QMAB_CONST1
+	VMOVDQU32 0x40(R10), QMAB_CONST2
+	VMOVDQU32 0x80(R10), QMAB_CONST3
 	RET
 
 TEXT ·__find_quote_mask_and_bits_avx512(SB), $0

--- a/find_whitespace_and_structurals_amd64.s
+++ b/find_whitespace_and_structurals_amd64.s
@@ -60,16 +60,16 @@ TEXT ·_find_whitespace_and_structurals(SB), $0-24
 	RET
 
 TEXT ·__find_whitespace_and_structurals(SB), $0
-	LEAQ LCDATA1<>(SB), BP
+	LEAQ LCDATA1<>(SB), R8
 
 	VMOVDQA   Y8, Y0        // vmovdqu    ymm0, yword [rdi]
 	VMOVDQA   Y9, Y1        // vmovdqu    ymm1, yword [rsi]
-	VMOVDQA   (BP), Y2      // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
+	VMOVDQA   (R8), Y2      // vmovdqa    ymm2, yword 0[rbp] /* [rip + LCPI0_0] */
 	VPSHUFB   Y0, Y2, Y3    // vpshufb    ymm3, ymm2, ymm0
 	VPSRLD    $4, Y0, Y0    // vpsrld    ymm0, ymm0, 4
-	VMOVDQA   0x40(BP), Y4  // vmovdqa    ymm4, yword 32[rbp] /* [rip + LCPI0_1] */
+	VMOVDQA   0x40(R8), Y4  // vmovdqa    ymm4, yword 32[rbp] /* [rip + LCPI0_1] */
 	VPAND     Y4, Y0, Y0    // vpand    ymm0, ymm0, ymm4
-	VMOVDQA   0x80(BP), Y5  // vmovdqa    ymm5, yword 64[rbp] /* [rip + LCPI0_2] */
+	VMOVDQA   0x80(R8), Y5  // vmovdqa    ymm5, yword 64[rbp] /* [rip + LCPI0_2] */
 	VPSHUFB   Y0, Y5, Y0    // vpshufb    ymm0, ymm5, ymm0
 	VPAND     Y3, Y0, Y0    // vpand    ymm0, ymm0, ymm3
 	VPSHUFB   Y1, Y2, Y2    // vpshufb    ymm2, ymm2, ymm1
@@ -77,7 +77,7 @@ TEXT ·__find_whitespace_and_structurals(SB), $0
 	VPAND     Y4, Y1, Y1    // vpand    ymm1, ymm1, ymm4
 	VPSHUFB   Y1, Y5, Y1    // vpshufb    ymm1, ymm5, ymm1
 	VPAND     Y2, Y1, Y1    // vpand    ymm1, ymm1, ymm2
-	VMOVDQA   0xc0(BP), Y2  // vmovdqa    ymm2, yword 96[rbp] /* [rip + LCPI0_3] */
+	VMOVDQA   0xc0(R8), Y2  // vmovdqa    ymm2, yword 96[rbp] /* [rip + LCPI0_3] */
 	VPAND     Y2, Y0, Y3    // vpand    ymm3, ymm0, ymm2
 	VPXOR     Y4, Y4, Y4    // vpxor    ymm4, ymm4, ymm4
 	VPCMPEQB  Y4, Y3, Y3    // vpcmpeqb    ymm3, ymm3, ymm4
@@ -89,7 +89,7 @@ TEXT ·__find_whitespace_and_structurals(SB), $0
 	ORQ       AX, SI        // or    rsi, rax
 	NOTQ      SI            // not    rsi
 	MOVQ      SI, (CX)      // mov    qword [rcx], rsi
-	VMOVDQA   0x100(BP), Y2 // vmovdqa    ymm2, yword 128[rbp] /* [rip + LCPI0_4] */
+	VMOVDQA   0x100(R8), Y2 // vmovdqa    ymm2, yword 128[rbp] /* [rip + LCPI0_4] */
 	VPAND     Y2, Y0, Y0    // vpand    ymm0, ymm0, ymm2
 	VPCMPEQB  Y4, Y0, Y0    // vpcmpeqb    ymm0, ymm0, ymm4
 	VPAND     Y2, Y1, Y1    // vpand    ymm1, ymm1, ymm2
@@ -124,13 +124,13 @@ TEXT ·_find_whitespace_and_structurals_avx512(SB), $0-24
 #define WSAS_CONST_5 Z25
 
 TEXT ·__init_whitespace_and_structurals_avx512(SB), $0
-	LEAQ      LCDATA1<>(SB), BP
+	LEAQ      LCDATA1<>(SB), R8
 	VPXORD    ZERO_CONST, ZERO_CONST, ZERO_CONST
-	VMOVDQU32 0x000(BP), WSAS_CONST_1
-	VMOVDQU32 0x040(BP), WSAS_CONST_2
-	VMOVDQU32 0x080(BP), WSAS_CONST_3
-	VMOVDQU32 0x0c0(BP), WSAS_CONST_4
-	VMOVDQU32 0x100(BP), WSAS_CONST_5
+	VMOVDQU32 0x000(R8), WSAS_CONST_1
+	VMOVDQU32 0x040(R8), WSAS_CONST_2
+	VMOVDQU32 0x080(R8), WSAS_CONST_3
+	VMOVDQU32 0x0c0(R8), WSAS_CONST_4
+	VMOVDQU32 0x100(R8), WSAS_CONST_5
 	RET
 
 TEXT ·__find_whitespace_and_structurals_avx512(SB), $0

--- a/parse_number_amd64.s
+++ b/parse_number_amd64.s
@@ -783,7 +783,7 @@ DATA LCTABLE<>+0x1840(SB)/8, $0x0101010101010101
 // end of structural_or_whitespace_or_exponent_or_decimal_negated
 GLOBL LCTABLE<>(SB), 8, $6216
 
-TEXT ·_parse_number(SB), $0-56
+TEXT ·_parse_number(SB), $8-56
 
 	MOVQ buf+0(FP), DI
 	MOVQ offset+8(FP), SI

--- a/parse_string_amd64.s
+++ b/parse_string_amd64.s
@@ -69,7 +69,7 @@ DATA LCDATA1<>+0x230(SB)/8, $0x0000000000000000
 DATA LCDATA1<>+0x238(SB)/8, $0x0000000000000000
 GLOBL LCDATA1<>(SB), 8, $576
 
-TEXT ·_parse_string_validate_only(SB), $0-40
+TEXT ·_parse_string_validate_only(SB), $8-40
 
 	MOVQ src+0(FP), DI
 	MOVQ maxStringSize+8(FP), SI
@@ -257,7 +257,7 @@ LBB0_31:
 	MOVQ AX, result+32(FP)
 	RET
 
-TEXT ·_parse_string(SB), $0-32
+TEXT ·_parse_string(SB), $8-32
 
 	MOVQ src+0(FP), DI
 	MOVQ dst+8(FP), SI


### PR DESCRIPTION
Avoid using BP register when using zero frame, since it confuses profiling and vet check will be in next version.

Needs test on AVX512.

> See discussion on Slack and `golang-dev`
> 
> https://gophers.slack.com/archives/C6WDZJ70S/p1598210629000900
> https://groups.google.com/g/golang-dev/c/aLn9t8tKg2o/m/Kw-N7lUuBAAJ
> 
> Summary:
> 
> * `BP` should be callee-save (poorly documented, even some standard library assembly didn't handle this correctly until recently)
> * `BP` "will be saved automatically if there is a nonzero frame size" https://golang.org/cl/248260
> 
> * Use the "nonzero frame size" hack in the case where `BP` has been used

