### PR TITLE
Add value exhange

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,26 @@ BenchmarkUpdate_center/copy-32                	    1665	    708717 ns/op	 752.31
 BenchmarkUpdate_center/nocopy-32              	    2241	    536027 ns/op	 994.68 MB/s	    2130 B/op	      58 allocs/op
 ```
 
+### In-place Value Replacement
+
+It is possible to replace a few, basic internal values.
+This means that when re-parsing or re-serializing the parsed JSON these values will be output.
+
+Boolean (true/false) and null values can be freely exchanged.
+
+Numeric values (float, int, uint) can be exchanged freely.
+
+Strings can also be exchanged with different values.
+
+Strings and numbers can be exchanged. However, note that there is no checks for numbers inserted as object keys,
+so if used for this invalid JSON is possible.
+
+There is no way to modify objects, arrays, other than value types above inside each.
+It is not possible to remove or add elements.
+
+To replace a value, of value referenced by an `Iter` simply call `SetNull`, `SetBool`, `SetFloat`, `SetInt`, `SetUInt`,
+`SetString` or `SetStringBytes`.
+
 ## Design
 
 `simdjson-go` follows the same two stage design as `simdjson`. 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/json-iterator/go v1.1.9
-	github.com/klauspost/compress v1.11.7
+	github.com/klauspost/compress v1.13.6
 	github.com/klauspost/cpuid/v2 v2.0.6
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
-github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
+github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid/v2 v2.0.6 h1:dQ5ueTiftKxp0gyjKSx5+8BtPWkyQbd95m8Gys/RarI=
 github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=

--- a/parse_json_amd64.go
+++ b/parse_json_amd64.go
@@ -38,10 +38,11 @@ func (pj *internalParsedJson) initialize(size int) {
 	if stringsSize < 128 {
 		stringsSize = 128 // always allocate at least 128 for the string buffer
 	}
-	if cap(pj.Strings) < stringsSize {
-		pj.Strings = make([]byte, 0, stringsSize)
+	if pj.Strings != nil && cap(pj.Strings.B) >= stringsSize {
+		pj.Strings.B = pj.Strings.B[:0]
+	} else {
+		pj.Strings = &TStrings{make([]byte, 0, stringsSize)}
 	}
-	pj.Strings = pj.Strings[:0]
 	if cap(pj.containingScopeOffset) < maxdepth {
 		pj.containingScopeOffset = make([]uint64, 0, maxdepth)
 	}

--- a/parsed_json.go
+++ b/parsed_json.go
@@ -17,18 +17,16 @@
 package simdjson
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math"
 	"strconv"
 )
 
-const JSONVALUEMASK = 0xffffffffffffff
-const JSONTAGMASK = 0xff << 56
-const STRINGBUFBIT = 0x80000000000000
+const JSONVALUEMASK = 0xff_ffff_ffff_ffff
+const JSONTAGOFFSET = 56
+const JSONTAGMASK = 0xff << JSONTAGOFFSET
+const STRINGBUFBIT = 0x80_0000_0000_0000
 const STRINGBUFMASK = 0x7fffffffffffff
 
 const maxdepth = 128
@@ -59,10 +57,14 @@ func (f FloatFlag) Flags(more ...FloatFlag) FloatFlags {
 	return FloatFlags(f)
 }
 
+type TStrings struct {
+	B []byte
+}
+
 type ParsedJson struct {
 	Message []byte
 	Tape    []uint64
-	Strings []byte
+	Strings *TStrings
 
 	// allows to reuse the internal structures without exposing it.
 	internal *internalParsedJson
@@ -111,10 +113,43 @@ func (pj *ParsedJson) stringByteAt(offset, length uint64) ([]byte, error) {
 	}
 
 	offset = offset & STRINGBUFMASK
-	if offset+length > uint64(len(pj.Strings)) {
-		return nil, fmt.Errorf("string buffer offset (%v) outside valid area (%v)", offset+length, len(pj.Strings))
+	if offset+length > uint64(len(pj.Strings.B)) {
+		return nil, fmt.Errorf("string buffer offset (%v) outside valid area (%v)", offset+length, len(pj.Strings.B))
 	}
-	return pj.Strings[offset : offset+length], nil
+	return pj.Strings.B[offset : offset+length], nil
+}
+
+// Clone returns a deep clone of the ParsedJson.
+// If a nil destination is sent a new will be created.
+func (pj *ParsedJson) Clone(dst *ParsedJson) *ParsedJson {
+	if dst == nil {
+		dst = &ParsedJson{
+			Message:  make([]byte, len(pj.Message)),
+			Tape:     make([]uint64, len(pj.Tape)),
+			Strings:  &TStrings{make([]byte, len(pj.Strings.B))},
+			internal: nil,
+		}
+	} else {
+		if cap(dst.Message) < len(pj.Message) {
+			dst.Message = make([]byte, len(pj.Message))
+		}
+		if cap(dst.Tape) < len(pj.Tape) {
+			dst.Tape = make([]uint64, len(pj.Tape))
+		}
+		if dst.Strings == nil {
+			dst.Strings = &TStrings{make([]byte, len(pj.Strings.B))}
+		} else if cap(dst.Strings.B) < len(pj.Strings.B) {
+			dst.Strings.B = make([]byte, len(pj.Strings.B))
+		}
+	}
+	dst.internal = nil
+	dst.Tape = dst.Tape[:len(pj.Tape)]
+	copy(dst.Tape, pj.Tape)
+	dst.Message = dst.Message[:len(pj.Message)]
+	copy(dst.Message, pj.Message)
+	dst.Strings.B = dst.Strings.B[:len(pj.Strings.B)]
+	copy(dst.Strings.B, pj.Strings.B)
+	return dst
 }
 
 // Iter represents a section of JSON.
@@ -136,32 +171,6 @@ type Iter struct {
 
 	// current tag
 	t Tag
-}
-
-// loadTape will load the input from the supplied readers.
-func loadTape(tape, strings io.Reader) (*ParsedJson, error) {
-	b, err := ioutil.ReadAll(tape)
-	if err != nil {
-		return nil, err
-	}
-	if len(b)&7 != 0 {
-		return nil, errors.New("unexpected tape length, should be modulo 8 bytes")
-	}
-	dst := ParsedJson{
-		Tape:    make([]uint64, len(b)/8),
-		Strings: nil,
-	}
-	// Read tape
-	for i := range dst.Tape {
-		dst.Tape[i] = binary.LittleEndian.Uint64(b[i*8 : i*8+8])
-	}
-	// Read stringbuf
-	b, err = ioutil.ReadAll(strings)
-	if err != nil {
-		return nil, err
-	}
-	dst.Strings = b
-	return &dst, nil
 }
 
 // Advance will read the type of the next element
@@ -507,7 +516,7 @@ func (i *Iter) FloatFlags() (float64, FloatFlags, error) {
 			return 0, 0, errors.New("corrupt input: expected float, but no more values on tape")
 		}
 		v := math.Float64frombits(i.tape.Tape[i.off])
-		return v, 0, nil
+		return v, FloatFlags(i.cur), nil
 	case TagInteger:
 		if i.off >= len(i.tape.Tape) {
 			return 0, 0, errors.New("corrupt input: expected integer, but no more values on tape")
@@ -519,10 +528,24 @@ func (i *Iter) FloatFlags() (float64, FloatFlags, error) {
 			return 0, 0, errors.New("corrupt input: expected integer, but no more values on tape")
 		}
 		v := i.tape.Tape[i.off]
-		return float64(v), FloatFlags(i.cur), nil
+		return float64(v), 0, nil
 	default:
 		return 0, 0, fmt.Errorf("unable to convert type %v to float", i.t)
 	}
+}
+
+// SetFloat can change a float, int, uint or string with the specified value.
+// Attempting to change other types will return an error.
+func (i *Iter) SetFloat(v float64) error {
+	switch i.t {
+	case TagFloat, TagInteger, TagUint, TagString:
+		i.tape.Tape[i.off-1] = uint64(TagFloat) << JSONTAGOFFSET
+		i.tape.Tape[i.off] = math.Float64bits(v)
+		i.t = TagFloat
+		i.cur = 0
+		return nil
+	}
+	return fmt.Errorf("cannot set tag %s to float", i.t.String())
 }
 
 // Int returns the integer value of the next element.
@@ -559,6 +582,20 @@ func (i *Iter) Int() (int64, error) {
 	default:
 		return 0, fmt.Errorf("unable to convert type %v to float", i.t)
 	}
+}
+
+// SetInt can change a float, int, uint or string with the specified value.
+// Attempting to change other types will return an error.
+func (i *Iter) SetInt(v int64) error {
+	switch i.t {
+	case TagFloat, TagInteger, TagUint, TagString:
+		i.tape.Tape[i.off-1] = uint64(TagInteger) << JSONTAGOFFSET
+		i.tape.Tape[i.off] = uint64(v)
+		i.t = TagInteger
+		i.cur = uint64(v)
+		return nil
+	}
+	return fmt.Errorf("cannot set tag %s to int", i.t.String())
 }
 
 // Uint returns the unsigned integer value of the next element.
@@ -598,6 +635,20 @@ func (i *Iter) Uint() (uint64, error) {
 	}
 }
 
+// SetUInt can change a float, int, uint or string with the specified value.
+// Attempting to change other types will return an error.
+func (i *Iter) SetUInt(v uint64) error {
+	switch i.t {
+	case TagString, TagFloat, TagInteger, TagUint:
+		i.tape.Tape[i.off-1] = uint64(TagUint) << JSONTAGOFFSET
+		i.tape.Tape[i.off] = v
+		i.t = TagUint
+		i.cur = v
+		return nil
+	}
+	return fmt.Errorf("cannot set tag %s to uint", i.t.String())
+}
+
 // String() returns a string value.
 func (i *Iter) String() (string, error) {
 	if i.t != TagString {
@@ -610,7 +661,7 @@ func (i *Iter) String() (string, error) {
 	return i.tape.stringAt(i.cur, i.tape.Tape[i.off])
 }
 
-// StringBytes() returns a byte array.
+// StringBytes returns a string as byte array.
 func (i *Iter) StringBytes() ([]byte, error) {
 	if i.t != TagString {
 		return nil, errors.New("value is not string")
@@ -621,7 +672,29 @@ func (i *Iter) StringBytes() ([]byte, error) {
 	return i.tape.stringByteAt(i.cur, i.tape.Tape[i.off])
 }
 
-// StringCvt() returns a string representation of the value.
+// SetString can change a string, int, uint or float with the specified string.
+// Attempting to change other types will return an error.
+func (i *Iter) SetString(v string) error {
+	return i.SetStringBytes([]byte(v))
+}
+
+// SetStringBytes can change a string, int, uint or float with the specified string.
+// Attempting to change other types will return an error.
+// Sending nil will add an empty string.
+func (i *Iter) SetStringBytes(v []byte) error {
+	switch i.t {
+	case TagString, TagFloat, TagInteger, TagUint:
+		i.cur = ((uint64(TagString) << JSONTAGOFFSET) | STRINGBUFBIT) | uint64(len(i.tape.Strings.B))
+		i.tape.Tape[i.off-1] = i.cur
+		i.tape.Tape[i.off] = uint64(len(v))
+		i.t = TagString
+		i.tape.Strings.B = append(i.tape.Strings.B, v...)
+		return nil
+	}
+	return fmt.Errorf("cannot set tag %s to string", i.t.String())
+}
+
+// StringCvt returns a string representation of the value.
 // Root, Object and Arrays are not supported.
 func (i *Iter) StringCvt() (string, error) {
 	switch i.t {
@@ -649,7 +722,7 @@ func (i *Iter) StringCvt() (string, error) {
 	return "", fmt.Errorf("cannot convert type %s to string", TagToType[i.t])
 }
 
-// Root() returns the object embedded in root as an iterator
+// Root returns the object embedded in root as an iterator
 // along with the type of the content of the first element of the iterator.
 // An optional destination can be supplied to avoid allocations.
 func (i *Iter) Root(dst *Iter) (Type, *Iter, error) {
@@ -674,7 +747,7 @@ func (i *Iter) Root(dst *Iter) (Type, *Iter, error) {
 	return dst.AdvanceInto().Type(), dst, nil
 }
 
-// Bool() returns the bool value.
+// Bool returns the bool value.
 func (i *Iter) Bool() (bool, error) {
 	switch i.t {
 	case TagBoolTrue:
@@ -683,6 +756,38 @@ func (i *Iter) Bool() (bool, error) {
 		return false, nil
 	}
 	return false, fmt.Errorf("value is not bool, but %v", i.t)
+}
+
+// SetBool can change a bool or null type to bool with the specified value.
+// Attempting to change other types will return an error.
+func (i *Iter) SetBool(v bool) error {
+	switch i.t {
+	case TagBoolTrue, TagBoolFalse, TagNull:
+		if v {
+			i.t = TagBoolTrue
+			i.cur = 0
+			i.tape.Tape[i.off-1] = uint64(TagBoolTrue) << JSONTAGOFFSET
+		} else {
+			i.t = TagBoolFalse
+			i.cur = 0
+			i.tape.Tape[i.off-1] = uint64(TagBoolFalse) << JSONTAGOFFSET
+		}
+		return nil
+	}
+	return fmt.Errorf("cannot set tag %s to bool", i.t.String())
+}
+
+// SetNull can change a bool or null type to bool with null.
+// Attempting to change other types will return an error.
+func (i *Iter) SetNull() error {
+	switch i.t {
+	case TagBoolTrue, TagBoolFalse, TagNull:
+		i.t = TagNull
+		i.cur = 0
+		i.tape.Tape[i.off-1] = uint64(TagNull) << JSONTAGOFFSET
+		return nil
+	}
+	return fmt.Errorf("cannot set tag %s to null", i.t.String())
 }
 
 // Interface returns the value as an interface.
@@ -800,7 +905,7 @@ func (i *Iter) Array(dst *Array) (*Array, error) {
 
 func (pj *ParsedJson) Reset() {
 	pj.Tape = pj.Tape[:0]
-	pj.Strings = pj.Strings[:0]
+	pj.Strings.B = pj.Strings.B[:0]
 	pj.Message = pj.Message[:0]
 }
 

--- a/parsed_json_test.go
+++ b/parsed_json_test.go
@@ -17,11 +17,13 @@
 package simdjson
 
 import (
-	"encoding/binary"
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -97,73 +99,6 @@ var testCases = []struct {
 	{
 		name: "update-center",
 	},
-}
-
-func bytesToUint64(buf []byte) []uint64 {
-
-	tape := make([]uint64, len(buf)/8)
-	for i := range tape {
-		tape[i] = binary.LittleEndian.Uint64(buf[i*8:])
-	}
-	return tape
-}
-
-func testCTapeCtoGoTapeCompare(t *testing.T, ctape []uint64, csbuf []byte, pj internalParsedJson) {
-
-	gotape := pj.Tape
-
-	cindex, goindex := 0, 0
-	for goindex < len(gotape) {
-		if cindex == len(ctape) {
-			t.Errorf("TestCTapeCtoGoTapeCompare: unexpected, ctape at end, but gotape not yet")
-			break
-		}
-		cval, goval := ctape[cindex], gotape[goindex]
-
-		// Make sure the type is the same between the C and Go version
-		if cval>>56 != goval>>56 {
-			t.Errorf("TestCTapeCtoGoTapeCompare: got: %02x want: %02x", goval>>56, cval>>56)
-		}
-
-		ntype := Tag(goval >> 56)
-		switch ntype {
-		case TagRoot, TagObjectStart, TagObjectEnd, TagArrayStart, TagArrayEnd:
-			cindex++
-			goindex++
-
-		case TagString:
-			cpayload := cval & JSONVALUEMASK
-			cstrlen := binary.LittleEndian.Uint32(csbuf[cpayload : cpayload+4])
-			cstr := string(csbuf[cpayload+4 : cpayload+4+uint64(cstrlen)])
-			gostr, _ := pj.stringAt(goval&JSONVALUEMASK, gotape[goindex+1])
-			if cstr != gostr {
-				t.Errorf("TestCTapeCtoGoTapeCompare: got: %s want: %s", gostr, cstr)
-			}
-			cindex++
-			goindex += 2
-
-		case TagNull, TagBoolTrue, TagBoolFalse:
-			cindex++
-			goindex++
-
-		case TagInteger, TagFloat:
-			if ctape[cindex+1] != gotape[goindex+1] {
-				if ntype != TagFloat {
-					t.Errorf("TestCTapeCtoGoTapeCompare: got: %016x want: %016x", gotape[goindex+1], ctape[cindex+1])
-
-				}
-			}
-			cindex += 2
-			goindex += 2
-
-		default:
-			t.Errorf("TestCTapeCtoGoTapeCompare: unexpected token, got: %02x", ntype)
-		}
-	}
-
-	if cindex != len(ctape) {
-		t.Errorf("TestCTapeCtoGoTapeCompare: got: %d want: %d", cindex, len(ctape))
-	}
 }
 
 func BenchmarkIter_MarshalJSONBuffer(b *testing.B) {
@@ -248,5 +183,566 @@ func TestPrintJson(t *testing.T) {
 
 	if string(out) != expected {
 		t.Errorf("TestPrintJson: got: %s want: %s", out, expected)
+	}
+}
+
+func TestExchange(t *testing.T) {
+	input := `{"value": -20}`
+	pj, err := Parse([]byte(input), nil)
+	if err != nil {
+		t.Errorf("Parse failed: %v", err)
+		return
+	}
+	for i := 0; i < 200; i++ {
+		i := i
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			var cl *ParsedJson
+			var o *Object
+			for j := 0; j < 10; j++ {
+				cl = pj.Clone(cl)
+				iter := cl.Iter()
+				iter.Advance()
+				_, r, err := iter.Root(&iter)
+				if err != nil {
+					t.Fatalf("Root failed: %v", err)
+				}
+				o, err = r.Object(o)
+				if err != nil {
+					t.Fatalf("Object failed: %v", err)
+				}
+				_, _, err = o.NextElementBytes(r)
+				if err != nil {
+					t.Fatalf("NextElementBytes failed: %v", err)
+				}
+				want := uint64(i + j*100)
+				err = r.SetUInt(want)
+				if err != nil {
+					t.Fatalf("SetUInt failed: %v", err)
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+				v, err := r.Uint()
+				if err != nil {
+					t.Fatalf("Uint failed: %v", err)
+					return
+				}
+				if v != want {
+					t.Errorf("want %d, got %d", want, v)
+				}
+			}
+		})
+	}
+}
+
+func TestIter_SetNull(t *testing.T) {
+	if !SupportedCPU() {
+		t.SkipNow()
+	}
+	input := `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,true,false,"astring",-42,9223372036854775808,1.23455]}`
+	tests := []struct {
+		want string
+	}{
+		{
+			want: `{"0val":{"true":null,"false":null,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,null,null,"astring",-42,9223372036854775808,1.23455]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("null", func(t *testing.T) {
+			pj, err := Parse([]byte(input), nil)
+			if err != nil {
+				t.Errorf("parseMessage failed\n")
+				return
+			}
+			root := pj.Iter()
+			// Queue root
+			root.AdvanceInto()
+			if err != nil {
+				t.Errorf("root failed: %v", err)
+				return
+			}
+			iter := root
+			for {
+				typ := iter.Type()
+				switch typ {
+				case TypeBool, TypeNull:
+					//t.Logf("setting to %v", test.setTo)
+					err := iter.SetNull()
+					if err != nil {
+						t.Errorf("Unable to set value: %v", err)
+					}
+
+					if iter.Type() != TypeNull {
+						t.Errorf("Want type %v, got %v", TypeNull, iter.Type())
+					}
+				default:
+					err := iter.SetNull()
+					if err == nil {
+						t.Errorf("Value should not be settable for type %v", typ)
+					}
+				}
+				if iter.PeekNextTag() == TagEnd {
+					break
+				}
+				iter.AdvanceInto()
+			}
+			out, err := root.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != test.want {
+				t.Errorf("want: %s\n got: %s", test.want, string(out))
+			}
+		})
+	}
+}
+
+func TestIter_SetBool(t *testing.T) {
+	if !SupportedCPU() {
+		t.SkipNow()
+	}
+	input := `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,true,false,"astring",-42,9223372036854775808,1.23455]}`
+	tests := []struct {
+		setTo bool
+		want  string
+	}{
+		{
+			setTo: true,
+			want:  `{"0val":{"true":true,"false":true,"nullval":true},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[true,true,true,"astring",-42,9223372036854775808,1.23455]}`,
+		},
+		{
+			setTo: false,
+			want:  `{"0val":{"true":false,"false":false,"nullval":false},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[false,false,false,"astring",-42,9223372036854775808,1.23455]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprint(test.setTo), func(t *testing.T) {
+			pj, err := Parse([]byte(input), nil)
+			if err != nil {
+				t.Errorf("parseMessage failed\n")
+				return
+			}
+			root := pj.Iter()
+			// Queue root
+			root.AdvanceInto()
+			if err != nil {
+				t.Errorf("root failed: %v", err)
+				return
+			}
+			iter := root
+			for {
+				typ := iter.Type()
+				switch typ {
+				case TypeBool, TypeNull:
+					//t.Logf("setting to %v", test.setTo)
+					err := iter.SetBool(test.setTo)
+					if err != nil {
+						t.Errorf("Unable to set value: %v", err)
+					}
+					val, err := iter.Bool()
+					if err != nil {
+						t.Errorf("Unable to retrieve value: %v", err)
+					}
+
+					if val != test.setTo {
+						t.Errorf("Want value %v, got %v", test.setTo, val)
+					}
+				default:
+					err := iter.SetBool(test.setTo)
+					if err == nil {
+						t.Errorf("Value should not be settable for type %v", typ)
+					}
+				}
+				if iter.PeekNextTag() == TagEnd {
+					break
+				}
+				iter.AdvanceInto()
+			}
+			out, err := root.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != test.want {
+				t.Errorf("want: %s\n got: %s", test.want, string(out))
+			}
+		})
+	}
+}
+
+func TestIter_SetFloat(t *testing.T) {
+	if !SupportedCPU() {
+		t.SkipNow()
+	}
+	input := `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,true,false,"astring",-42,9223372036854775808,1.23455]}`
+	tests := []struct {
+		setTo float64
+		want  string
+	}{
+		{
+			setTo: 69.420,
+			want:  `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":69.42,"int":69.42,"uint":69.42},"stringval":"initial value","array":[null,true,false,"astring",69.42,69.42,69.42]}`,
+		},
+		{
+			setTo: 10e30,
+			want:  `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":1e+31,"int":1e+31,"uint":1e+31},"stringval":"initial value","array":[null,true,false,"astring",1e+31,1e+31,1e+31]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprint(test.setTo), func(t *testing.T) {
+			pj, err := Parse([]byte(input), nil)
+			if err != nil {
+				t.Errorf("parseMessage failed\n")
+				return
+			}
+			root := pj.Iter()
+			// Queue root
+			root.AdvanceInto()
+			if err != nil {
+				t.Errorf("root failed: %v", err)
+				return
+			}
+			iter := root
+			for {
+				typ := iter.Type()
+				switch typ {
+				case TypeInt, TypeFloat, TypeUint:
+					//t.Logf("setting to %v", test.setTo)
+					err := iter.SetFloat(test.setTo)
+					if err != nil {
+						t.Errorf("Unable to set value: %v", err)
+					}
+					val, err := iter.Float()
+					if err != nil {
+						t.Errorf("Unable to retrieve value: %v", err)
+					}
+
+					if val != test.setTo {
+						t.Errorf("Want value %v, got %v", test.setTo, val)
+					}
+				case TypeString:
+					// Do not replace strings...
+				default:
+					err := iter.SetFloat(test.setTo)
+					if err == nil {
+						t.Errorf("Value should not be settable for type %v", typ)
+					}
+				}
+				if iter.PeekNextTag() == TagEnd {
+					break
+				}
+				iter.AdvanceInto()
+			}
+			out, err := root.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != test.want {
+				t.Errorf("want: %s\n got: %s", test.want, string(out))
+			}
+		})
+	}
+}
+
+func TestIter_SetInt(t *testing.T) {
+	if !SupportedCPU() {
+		t.SkipNow()
+	}
+	input := `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,true,false,"astring",-42,9223372036854775808,1.23455]}`
+	tests := []struct {
+		setTo int64
+		want  string
+	}{
+		{
+			setTo: -69,
+			want:  `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":-69,"int":-69,"uint":-69},"stringval":"initial value","array":[null,true,false,"astring",-69,-69,-69]}`,
+		},
+		{
+			setTo: 42,
+			want:  `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":42,"int":42,"uint":42},"stringval":"initial value","array":[null,true,false,"astring",42,42,42]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprint(test.setTo), func(t *testing.T) {
+			pj, err := Parse([]byte(input), nil)
+			if err != nil {
+				t.Errorf("parseMessage failed\n")
+				return
+			}
+			root := pj.Iter()
+			// Queue root
+			root.AdvanceInto()
+			if err != nil {
+				t.Errorf("root failed: %v", err)
+				return
+			}
+			iter := root
+			for {
+				typ := iter.Type()
+				switch typ {
+				case TypeInt, TypeFloat, TypeUint:
+					//t.Logf("setting to %v", test.setTo)
+					err := iter.SetInt(test.setTo)
+					if err != nil {
+						t.Errorf("Unable to set value: %v", err)
+					}
+					val, err := iter.Int()
+					if err != nil {
+						t.Errorf("Unable to retrieve value: %v", err)
+					}
+
+					if val != test.setTo {
+						t.Errorf("Want value %v, got %v", test.setTo, val)
+					}
+				case TypeString:
+					// Do not replace strings...
+
+				default:
+					err := iter.SetInt(test.setTo)
+					if err == nil {
+						t.Errorf("Value should not be settable for type %v", typ)
+					}
+				}
+				if iter.PeekNextTag() == TagEnd {
+					break
+				}
+				iter.AdvanceInto()
+			}
+			out, err := root.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != test.want {
+				t.Errorf("want: %s\n got: %s", test.want, string(out))
+			}
+		})
+	}
+}
+
+func TestIter_SetUInt(t *testing.T) {
+	if !SupportedCPU() {
+		t.SkipNow()
+	}
+	input := `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,true,false,"astring",-42,9223372036854775808,1.23455]}`
+	tests := []struct {
+		setTo uint64
+		want  string
+	}{
+		{
+			setTo: 69,
+			want:  `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":69,"int":69,"uint":69},"stringval":"initial value","array":[null,true,false,"astring",69,69,69]}`,
+		},
+		{
+			setTo: 420,
+			want:  `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":420,"int":420,"uint":420},"stringval":"initial value","array":[null,true,false,"astring",420,420,420]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprint(test.setTo), func(t *testing.T) {
+			pj, err := Parse([]byte(input), nil)
+			if err != nil {
+				t.Errorf("parseMessage failed\n")
+				return
+			}
+			root := pj.Iter()
+			// Queue root
+			root.AdvanceInto()
+			if err != nil {
+				t.Errorf("root failed: %v", err)
+				return
+			}
+			iter := root
+			for {
+				typ := iter.Type()
+				switch typ {
+				case TypeInt, TypeFloat, TypeUint:
+					//t.Logf("setting to %v", test.setTo)
+					err := iter.SetUInt(test.setTo)
+					if err != nil {
+						t.Errorf("Unable to set value: %v", err)
+					}
+					val, err := iter.Uint()
+					if err != nil {
+						t.Errorf("Unable to retrieve value: %v", err)
+					}
+
+					if val != test.setTo {
+						t.Errorf("Want value %v, got %v", test.setTo, val)
+					}
+				case TypeString:
+					// Do not replace strings...
+				default:
+					err := iter.SetUInt(test.setTo)
+					if err == nil {
+						t.Errorf("Value should not be settable for type %v", typ)
+					}
+				}
+				if iter.PeekNextTag() == TagEnd {
+					break
+				}
+				iter.AdvanceInto()
+			}
+			out, err := root.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != test.want {
+				t.Errorf("want: %s\n got: %s", test.want, string(out))
+			}
+		})
+	}
+}
+
+func TestIter_SetString(t *testing.T) {
+	if !SupportedCPU() {
+		t.SkipNow()
+	}
+	input := `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,true,false,"astring",-42,9223372036854775808,1.23455]}`
+	tests := []struct {
+		setTo string
+		want  string
+	}{
+		{
+			setTo: "anotherval",
+			want:  `{"anotherval":{"anotherval":true,"anotherval":false,"anotherval":null},"anotherval":{"anotherval":"anotherval","anotherval":"anotherval","anotherval":"anotherval"},"anotherval":"anotherval","anotherval":[null,true,false,"anotherval","anotherval","anotherval","anotherval"]}`,
+		},
+		{
+			setTo: "",
+			want:  `{"":{"":true,"":false,"":null},"":{"":"","":"","":""},"":"","":[null,true,false,"","","",""]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprint(test.setTo), func(t *testing.T) {
+			pj, err := Parse([]byte(input), nil)
+			if err != nil {
+				t.Errorf("parseMessage failed\n")
+				return
+			}
+			root := pj.Iter()
+			// Queue root
+			root.AdvanceInto()
+			if err != nil {
+				t.Errorf("root failed: %v", err)
+				return
+			}
+			iter := root
+			for {
+				typ := iter.Type()
+				switch typ {
+				case TypeString, TypeInt, TypeFloat, TypeUint:
+					//t.Logf("setting to %v", test.setTo)
+					err := iter.SetString(test.setTo)
+					if err != nil {
+						t.Errorf("Unable to set value: %v", err)
+					}
+					val, err := iter.String()
+					if err != nil {
+						t.Errorf("Unable to retrieve value: %v", err)
+					}
+
+					if val != test.setTo {
+						t.Errorf("Want value %v, got %v", test.setTo, val)
+					}
+				default:
+					err := iter.SetString(test.setTo)
+					if err == nil {
+						t.Errorf("Value should not be settable for type %v", typ)
+					}
+				}
+				if iter.PeekNextTag() == TagEnd {
+					break
+				}
+				iter.AdvanceInto()
+			}
+			out, err := root.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != test.want {
+				t.Errorf("want: %s\n got: %s", test.want, string(out))
+			}
+		})
+	}
+}
+
+func TestIter_SetStringBytes(t *testing.T) {
+	if !SupportedCPU() {
+		t.SkipNow()
+	}
+	input := `{"0val":{"true":true,"false":false,"nullval":null},"1val":{"float":12.3456,"int":-42,"uint":9223372036854775808},"stringval":"initial value","array":[null,true,false,"astring",-42,9223372036854775808,1.23455]}`
+	tests := []struct {
+		setTo []byte
+		want  string
+	}{
+		{
+			setTo: []byte("anotherval"),
+			want:  `{"anotherval":{"anotherval":true,"anotherval":false,"anotherval":null},"anotherval":{"anotherval":"anotherval","anotherval":"anotherval","anotherval":"anotherval"},"anotherval":"anotherval","anotherval":[null,true,false,"anotherval","anotherval","anotherval","anotherval"]}`,
+		},
+		{
+			setTo: []byte{},
+			want:  `{"":{"":true,"":false,"":null},"":{"":"","":"","":""},"":"","":[null,true,false,"","","",""]}`,
+		},
+		{
+			setTo: []byte(nil),
+			want:  `{"":{"":true,"":false,"":null},"":{"":"","":"","":""},"":"","":[null,true,false,"","","",""]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprint(test.setTo), func(t *testing.T) {
+			pj, err := Parse([]byte(input), nil)
+			if err != nil {
+				t.Errorf("parseMessage failed\n")
+				return
+			}
+			root := pj.Iter()
+			// Queue root
+			root.AdvanceInto()
+			if err != nil {
+				t.Errorf("root failed: %v", err)
+				return
+			}
+			iter := root
+			for {
+				typ := iter.Type()
+				switch typ {
+				case TypeString, TypeInt, TypeFloat, TypeUint:
+					//t.Logf("setting to %v", test.setTo)
+					err := iter.SetStringBytes(test.setTo)
+					if err != nil {
+						t.Errorf("Unable to set value: %v", err)
+					}
+					val, err := iter.StringBytes()
+					if err != nil {
+						t.Errorf("Unable to retrieve value: %v", err)
+					}
+
+					if !bytes.Equal(val, test.setTo) {
+						t.Errorf("Want value %v, got %v", test.setTo, val)
+					}
+				default:
+					err := iter.SetStringBytes(test.setTo)
+					if err == nil {
+						t.Errorf("Value should not be settable for type %v", typ)
+					}
+				}
+				if iter.PeekNextTag() == TagEnd {
+					break
+				}
+				iter.AdvanceInto()
+			}
+			out, err := root.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != test.want {
+				t.Errorf("want: %s\n got: %s", test.want, string(out))
+			}
+		})
 	}
 }

--- a/parsed_json_test.go
+++ b/parsed_json_test.go
@@ -614,6 +614,10 @@ func TestIter_SetString(t *testing.T) {
 			setTo: "",
 			want:  `{"":{"":true,"":false,"":null},"":{"":"","":"","":""},"":"","":[null,true,false,"","","",""]}`,
 		},
+		{
+			setTo: "\t",
+			want:  `{"\t":{"\t":true,"\t":false,"\t":null},"\t":{"\t":"\t","\t":"\t","\t":"\t"},"\t":"\t","\t":[null,true,false,"\t","\t","\t","\t"]}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/parsed_serialize.go
+++ b/parsed_serialize.go
@@ -421,7 +421,7 @@ func (s *Serializer) Serialize(dst []byte, pj ParsedJson) []byte {
 	dst = append(dst, tmp[:n]...)
 	dst = append(dst, s.valuesCompBuf...)
 	if false {
-		fmt.Println("strings:", len(pj.Strings)+len(pj.Message), "->", len(s.sMsg), "tags:", rawTags, "->", len(s.tagsCompBuf), "values:", rawValues, "->", len(s.valuesCompBuf), "Total:", len(pj.Message)+len(pj.Strings)+len(pj.Tape)*8, "->", len(dst))
+		fmt.Println("strings:", len(pj.Strings.B)+len(pj.Message), "->", len(s.sMsg), "tags:", rawTags, "->", len(s.tagsCompBuf), "values:", rawValues, "->", len(s.valuesCompBuf), "Total:", len(pj.Message)+len(pj.Strings.B)+len(pj.Tape)*8, "->", len(dst))
 	}
 
 	return dst
@@ -500,16 +500,16 @@ func (s *Serializer) Deserialize(src []byte, dst *ParsedJson) (*ParsedJson, erro
 	if ss, err := binary.ReadUvarint(br); err != nil {
 		return dst, err
 	} else {
-		if uint64(cap(dst.Strings)) < ss || dst.Strings == nil {
-			dst.Strings = make([]byte, ss)
+		if dst.Strings == nil || uint64(cap(dst.Strings.B)) < ss {
+			dst.Strings = &TStrings{B: make([]byte, ss)}
 		}
-		dst.Strings = dst.Strings[:ss]
+		dst.Strings.B = dst.Strings.B[:ss]
 	}
 
 	// Decompress strings
 	var sWG sync.WaitGroup
 	var stringsErr, msgErr error
-	err := s.decBlock(br, dst.Strings, &sWG, &stringsErr)
+	err := s.decBlock(br, dst.Strings.B, &sWG, &stringsErr)
 	if err != nil {
 		return dst, err
 	}

--- a/parsed_serialize_test.go
+++ b/parsed_serialize_test.go
@@ -29,8 +29,6 @@ func BenchmarkSerialize(b *testing.B) {
 
 	bench := func(b *testing.B, s *Serializer) {
 		for _, tt := range testCases {
-			s := NewSerializer()
-			var once sync.Once
 			b.Run(tt.name, func(b *testing.B) {
 				org := loadCompressed(b, tt.name)
 				pj, err := Parse(org, nil)
@@ -38,9 +36,6 @@ func BenchmarkSerialize(b *testing.B) {
 					b.Fatal(err)
 				}
 				output := s.Serialize(nil, *pj)
-				once.Do(func() {
-					b.Log(len(org), "(JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(org)), "%")
-				})
 				//_ = ioutil.WriteFile(filepath.Join("testdata", tt.name+".compressed"), output, os.ModePerm)
 				b.SetBytes(int64(len(org)))
 				b.ReportAllocs()
@@ -48,6 +43,7 @@ func BenchmarkSerialize(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					output = s.Serialize(output[:0], *pj)
 				}
+				b.ReportMetric(100*float64(len(output))/float64(len(org)), "pct")
 			})
 		}
 	}
@@ -87,9 +83,6 @@ func BenchmarkDeSerialize(b *testing.B) {
 				}
 
 				output := s.Serialize(nil, *pj)
-				if false {
-					b.Log(len(org), "(JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(org)), "%")
-				}
 				//_ = ioutil.WriteFile(filepath.Join("testdata", tt.name+".compressed"), output, os.ModePerm)
 				pj2, err := s.Deserialize(output, nil)
 				if err != nil {
@@ -105,6 +98,7 @@ func BenchmarkDeSerialize(b *testing.B) {
 						b.Fatal(err)
 					}
 				}
+				b.ReportMetric(100*float64(len(output))/float64(len(org)), "pct")
 			})
 		}
 	}
@@ -143,9 +137,6 @@ func BenchmarkSerializeNDJSON(b *testing.B) {
 	}
 	bench := func(b *testing.B, s *Serializer) {
 		output := s.Serialize(nil, *pj)
-		if true {
-			b.Log(len(ndjson), "(JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(ndjson)), "%")
-		}
 		//_ = ioutil.WriteFile(filepath.Join("testdata", tt.name+".compressed"), output, os.ModePerm)
 		b.SetBytes(int64(len(ndjson)))
 		b.ReportAllocs()
@@ -153,6 +144,7 @@ func BenchmarkSerializeNDJSON(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			output = s.Serialize(output[:0], *pj)
 		}
+		b.ReportMetric(100*float64(len(output))/float64(len(ndjson)), "pct")
 	}
 	b.Run("default", func(b *testing.B) {
 		s := NewSerializer()
@@ -188,9 +180,6 @@ func BenchmarkDeSerializeNDJSON(b *testing.B) {
 	}
 	bench := func(b *testing.B, s *Serializer) {
 		output := s.Serialize(nil, *pj)
-		if true {
-			b.Log(len(ndjson), "(JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(ndjson)), "%")
-		}
 		pj2, err := s.Deserialize(output, nil)
 		if err != nil {
 			b.Fatal(err)
@@ -205,6 +194,7 @@ func BenchmarkDeSerializeNDJSON(b *testing.B) {
 				b.Fatal(err)
 			}
 		}
+		b.ReportMetric(100*float64(len(output))/float64(len(ndjson)), "pct")
 	}
 	b.Run("default", func(b *testing.B) {
 		s := NewSerializer()

--- a/stage2_build_tape_amd64.go
+++ b/stage2_build_tape_amd64.go
@@ -93,20 +93,21 @@ func parseString(pj *ParsedJson, idx uint64, maxStringSize uint64, needCopy bool
 		pj.write_tape(idx+1, '"')
 	} else {
 		// Make sure we account for at least 32 bytes additional space due to
-		requiredLen := uint64(len(pj.Strings)) + size + 32
-		if requiredLen >= uint64(cap(pj.Strings)) {
-			newSize := uint64(cap(pj.Strings) * 2)
+		strs := pj.Strings.B
+		requiredLen := uint64(len(strs)) + size + 32
+		if requiredLen >= uint64(cap(strs)) {
+			newSize := uint64(cap(strs) * 2)
 			if newSize < requiredLen {
 				newSize = requiredLen + size // add size once more to account for further space
 			}
-			strs := make([]byte, len(pj.Strings), newSize)
-			copy(strs, pj.Strings)
-			pj.Strings = strs
+			strs = make([]byte, len(strs), newSize)
+			copy(strs, pj.Strings.B)
+			pj.Strings.B = strs
 		}
-		start := len(pj.Strings)
-		_ = parseStringSimd(buf, &pj.Strings) // We can safely ignore the result since we validate above
+		start := len(strs)
+		_ = parseStringSimd(buf, &pj.Strings.B) // We can safely ignore the result since we validate above
 		pj.write_tape(uint64(STRINGBUFBIT+start), '"')
-		size = uint64(len(pj.Strings) - start)
+		size = uint64(len(pj.Strings.B) - start)
 	}
 	// put length onto the tape
 	pj.Tape = append(pj.Tape, size)


### PR DESCRIPTION
Make it possible to change basic, size compatible values.

This means that when re-parsing or re-serializing the parsed JSON these values will be output.

Boolean (true/false) and null values can be freely exchanged.

Numeric values (float, int, uint) can be exchanged freely.

Strings can also be exchanged with different values.

Strings and numbers can be exchanged. However, note that there is no checks for numbers inserted as object keys,
so if used for this invalid JSON is possible.

There is no way to modify objects, arrays, other than value types above inside each.
It is not possible to remove or add elements.

To replace a value, of value referenced by an `Iter` simply call `SetNull`, `SetBool`, `SetFloat`, `SetInt`, `SetUInt`,
`SetString` or `SetStringBytes`.

A clone function has been added to safely allow modifications of the same parsed json.

Fixes #45