### PR TITLE
Add Object Path selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ For any `Iter` it is possible to marshal the recursive content of the Iter using
 
 Currently, it is not possible to unmarshal into structs.
 
+### Search by path
+
+It is possible to search by path to find elements by traversing objects.
+
+For example:
+
+```
+	// Find element in path.
+	elem, err := i.FindElement("Image/URL", nil)
+```
+
+Will locate the field inside a json object with the following structure:
+
+```
+{
+    "Image": {
+        "URL": "value"
+    }
+}
+```
+
+The values can be any type. The [Element](https://pkg.go.dev/github.com/minio/simdjson-go#Element)
+will contain the element information and an Iter to access the content.
+
 ## Parsing Objects
 
 If you are only interested in one key in an object you can use `FindKey` to quickly select it.

--- a/parsed_json_test.go
+++ b/parsed_json_test.go
@@ -19,7 +19,9 @@ package simdjson
 import (
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"testing"
 
@@ -249,4 +251,49 @@ func TestPrintJson(t *testing.T) {
 	if string(out) != expected {
 		t.Errorf("TestPrintJson: got: %s want: %s", out, expected)
 	}
+}
+
+func ExampleIter_FindElement() {
+	input := `{
+    "Image":
+    {
+        "Animated": false,
+        "Height": 600,
+        "IDs":
+        [
+            116,
+            943,
+            234,
+            38793
+        ],
+        "Thumbnail":
+        {
+            "Height": 125,
+            "Url": "http://www.example.com/image/481989943",
+            "Width": 100
+        },
+        "Title": "View from 15th Floor",
+        "Width": 800
+    },
+	"Alt": "Image of city" 
+}`
+	pj, err := Parse([]byte(input), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	i := pj.Iter()
+
+	// Find element in path.
+	elem, err := i.FindElement("Image/Thumbnail/Width", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print result:
+	fmt.Println(elem.Type)
+	fmt.Println(elem.Iter.StringCvt())
+
+	// Output:
+	// int
+	// 100 <nil>
 }

--- a/parsed_object.go
+++ b/parsed_object.go
@@ -19,6 +19,7 @@ package simdjson
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Object represents a JSON object.
@@ -134,6 +135,76 @@ func (o *Object) FindKey(key string, dst *Element) *Element {
 			return nil
 		}
 		return dst
+	}
+}
+
+// ErrNotFound is returned
+var ErrNotFound = errors.New("not found")
+
+// FindPath allows searching for fields and objects by path.
+// Separate each object name by /.
+// For example `Image/Url` will search the current object for an "Image"
+// object and return the value of the "Url" element.
+// ErrNotFound is returned if any part of the path cannot be found.
+// If the tape contains an error it will be returned.
+// The object will not be advanced.
+func (o *Object) FindPath(path string, dst *Element) (*Element, error) {
+	tmp := o.tape.Iter()
+	tmp.off = o.off
+	p := strings.Split(path, "/")
+	key := p[0]
+	p = p[1:]
+	for {
+		typ := tmp.Advance()
+		// We want name and at least one value.
+		if typ != TypeString || tmp.off+1 >= len(tmp.tape.Tape) {
+			return dst, ErrNotFound
+		}
+		// Advance must be string or end of object
+		offset := tmp.cur
+		length := tmp.tape.Tape[tmp.off]
+		if int(length) != len(key) {
+			// Skip the value.
+			t := tmp.Advance()
+			if t == TypeNone {
+				// Not found...
+				return dst, ErrNotFound
+			}
+			continue
+		}
+		// Read name
+		name, err := tmp.tape.stringByteAt(offset, length)
+		if err != nil {
+			return dst, err
+		}
+
+		if string(name) != key {
+			// Skip the value
+			tmp.Advance()
+			continue
+		}
+		// Done...
+		if len(p) == 0 {
+			if dst == nil {
+				dst = &Element{}
+			}
+			dst.Name = key
+			dst.Type, err = tmp.AdvanceIter(&dst.Iter)
+			if err != nil {
+				return dst, err
+			}
+			return dst, nil
+		}
+
+		t, err := tmp.AdvanceIter(&tmp)
+		if err != nil {
+			return dst, err
+		}
+		if t != TypeObject {
+			return dst, fmt.Errorf("value of key %v is not an object", key)
+		}
+		key = p[0]
+		p = p[1:]
 	}
 }
 

--- a/parsed_object.go
+++ b/parsed_object.go
@@ -139,7 +139,7 @@ func (o *Object) FindKey(key string, dst *Element) *Element {
 }
 
 // ErrNotFound is returned
-var ErrNotFound = errors.New("not found")
+var ErrNotFound = errors.New("path not found")
 
 // FindPath allows searching for fields and objects by path.
 // Separate each object name by /.

--- a/parsed_object_test.go
+++ b/parsed_object_test.go
@@ -1,0 +1,185 @@
+package simdjson
+
+import (
+	"fmt"
+	"log"
+	"testing"
+)
+
+func TestObject_FindPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantName string
+		wantType Type
+		wantVal  string
+		wantErr  bool
+	}{
+		{
+			name:     "top",
+			path:     "Alt",
+			wantName: "Alt",
+			wantType: TypeString,
+			wantVal:  `"Image of city"`,
+		},
+		{
+			name:     "nested-1",
+			path:     "Image/Animated",
+			wantName: "Animated",
+			wantType: TypeBool,
+			wantVal:  "false",
+		},
+		{
+			name:     "nested-2",
+			path:     "Image/Thumbnail/Url",
+			wantName: "Url",
+			wantType: TypeString,
+			wantVal:  `"http://www.example.com/image/481989943"`,
+		},
+		{
+			name:     "int",
+			path:     "Image/Height",
+			wantName: "Height",
+			wantType: TypeInt,
+			wantVal:  `600`,
+		},
+		{
+			name:     "obj",
+			path:     "Image/Thumbnail",
+			wantName: "Thumbnail",
+			wantType: TypeObject,
+			wantVal:  `{"Height":125,"Url":"http://www.example.com/image/481989943","Width":100}`,
+		},
+		{
+			name:     "array",
+			path:     "Image/IDs",
+			wantName: "IDs",
+			wantType: TypeArray,
+			wantVal:  `[116,943,234,38793]`,
+		},
+		{
+			name:    "404",
+			path:    "Image/NonEx",
+			wantErr: true,
+		},
+	}
+	input := `{
+    "Image":
+    {
+        "Animated": false,
+        "Height": 600,
+        "IDs":
+        [
+            116,
+            943,
+            234,
+            38793
+        ],
+        "Thumbnail":
+        {
+            "Height": 125,
+            "Url": "http://www.example.com/image/481989943",
+            "Width": 100
+        },
+        "Title": "View from 15th Floor",
+        "Width": 800
+    },
+	"Alt": "Image of city" 
+}`
+	for _, tt := range tests {
+		pj, err := Parse([]byte(input), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			i := pj.Iter()
+			i.AdvanceInto()
+			_, root, err := i.Root(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			obj, err := root.Object(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			elem, err := obj.FindPath(tt.path, nil)
+			if err != nil && !tt.wantErr {
+				t.Fatal(err)
+			}
+			if tt.wantErr {
+				return
+			}
+			if elem.Type != tt.wantType {
+				t.Errorf("Want type %v, got %v", tt.wantType, elem.Type)
+			}
+			if elem.Name != tt.wantName {
+				t.Errorf("Want name %v, got %v", tt.wantName, elem.Name)
+			}
+			ser, err := elem.Iter.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(ser) != tt.wantVal {
+				t.Errorf("want '%s', got '%s'", tt.wantVal, string(ser))
+			}
+		})
+	}
+}
+
+func ExampleObject_FindPath() {
+	input := `{
+    "Image":
+    {
+        "Animated": false,
+        "Height": 600,
+        "IDs":
+        [
+            116,
+            943,
+            234,
+            38793
+        ],
+        "Thumbnail":
+        {
+            "Height": 125,
+            "Url": "http://www.example.com/image/481989943",
+            "Width": 100
+        },
+        "Title": "View from 15th Floor",
+        "Width": 800
+    },
+	"Alt": "Image of city" 
+}`
+	pj, err := Parse([]byte(input), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	i := pj.Iter()
+	i.AdvanceInto()
+
+	// Grab root
+	_, root, err := i.Root(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Grab top object
+	obj, err := root.Object(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Find element in path.
+	elem, err := obj.FindPath("Image/Thumbnail/Url", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print result:
+	fmt.Println(elem.Type)
+	fmt.Println(elem.Iter.String())
+
+	// Output:
+	// string
+	// http://www.example.com/image/481989943 <nil>
+}


### PR DESCRIPTION
### Search by path

It is possible to search by path to find elements by traversing objects.

For example:

```
	// Find element in path.
	elem, err := i.FindElement("Image/URL", nil)
```

Will locate the field inside a json object with the following structure:

```
{
    "Image": {
        "URL": "value"
    }
}
```