### PR TITLE
Faster constant compares and numbers

### DIFF
--- a/parse_json_amd64_test.go
+++ b/parse_json_amd64_test.go
@@ -233,7 +233,9 @@ func TestParseNumber(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tag, val, flags := parseNumber([]byte(fmt.Sprintf(`%s:`, tc.input)))
+		id, val := parseNumber([]byte(fmt.Sprintf(`%s:`, tc.input)))
+		tag := Tag(id >> JSONTAGOFFSET)
+		flags := id & JSONVALUEMASK
 		if tag != tc.wantTag {
 			t.Errorf("TestParseNumber: got: %v want: %v", tag, tc.wantTag)
 		}
@@ -304,7 +306,8 @@ func TestParseInt64(t *testing.T) {
 		test := &parseInt64Tests[i]
 		t.Run(test.in, func(t *testing.T) {
 
-			tag, val, _ := parseNumber([]byte(fmt.Sprintf(`%s:`, test.in)))
+			id, val := parseNumber([]byte(fmt.Sprintf(`%s:`, test.in)))
+			tag := Tag(id >> JSONTAGOFFSET)
 			if tag != test.tag {
 				// Ignore intentionally bad syntactical errors
 				t.Errorf("TestParseInt64: got: %v want: %v", tag, test.tag)
@@ -487,7 +490,8 @@ func TestParseFloat64(t *testing.T) {
 	for i := 0; i < len(atoftests); i++ {
 		test := &atoftests[i]
 		t.Run(test.in, func(t *testing.T) {
-			tag, val, _ := parseNumber([]byte(fmt.Sprintf(`%s:`, test.in)))
+			id, val := parseNumber([]byte(fmt.Sprintf(`%s:`, test.in)))
+			tag := Tag(id >> JSONTAGOFFSET)
 			switch tag {
 			case TagEnd:
 				if test.err == nil {

--- a/parse_number_amd64.go
+++ b/parse_number_amd64.go
@@ -66,14 +66,14 @@ var isNumberRune = [256]uint8{
 // parseNumber will parse the number starting in the buffer.
 // Any non-number characters at the end will be ignored.
 // Returns TagEnd if no valid value found be found.
-func parseNumber(buf []byte) (tag Tag, val, flags uint64) {
+func parseNumber(buf []byte) (id, val uint64) {
 	pos := 0
 	found := uint8(0)
 	for i, v := range buf {
 		t := isNumberRune[v]
 		if t == 0 {
 			//fmt.Println("aborting on", string(v), "in", string(buf[:i]))
-			return TagEnd, 0, 0
+			return 0, 0
 		}
 		if t == isEOVFlag {
 			break
@@ -81,60 +81,61 @@ func parseNumber(buf []byte) (tag Tag, val, flags uint64) {
 		if t&isMustHaveDigitNext > 0 {
 			// A period and minus must be followed by a digit
 			if len(buf) < i+2 || isNumberRune[buf[i+1]]&isDigitFlag == 0 {
-				return TagEnd, 0, 0
+				return 0, 0
 			}
 		}
 		found |= t
 		pos = i + 1
 	}
 	if pos == 0 {
-		return TagEnd, 0, 0
+		return 0, 0
 	}
 	const maxIntLen = 20
+	floatTag := uint64(TagFloat) << JSONTAGOFFSET
 
 	// Only try integers if we didn't find any float exclusive and it can fit in an integer.
 	if found&isFloatOnlyFlag == 0 && pos <= maxIntLen {
 		if found&isMinusFlag == 0 {
 			if pos > 1 && buf[0] == '0' {
 				// Integers cannot have a leading zero.
-				return TagEnd, 0, 0
+				return 0, 0
 			}
 		} else {
 			if pos > 2 && buf[1] == '0' {
 				// Integers cannot have a leading zero after minus.
-				return TagEnd, 0, 0
+				return 0, 0
 			}
 		}
 		i64, err := strconv.ParseInt(unsafeBytesToString(buf[:pos]), 10, 64)
 		if err == nil {
-			return TagInteger, uint64(i64), 0
+			return uint64(TagInteger) << JSONTAGOFFSET, uint64(i64)
 		}
 		if errors.Is(err, strconv.ErrRange) {
-			flags |= uint64(FloatOverflowedInteger)
+			floatTag |= uint64(FloatOverflowedInteger)
 		}
 
 		if found&isMinusFlag == 0 {
 			u64, err := strconv.ParseUint(unsafeBytesToString(buf[:pos]), 10, 64)
 			if err == nil {
-				return TagUint, u64, 0
+				return uint64(TagUint) << JSONTAGOFFSET, u64
 			}
 			if errors.Is(err, strconv.ErrRange) {
-				flags |= uint64(FloatOverflowedInteger)
+				floatTag |= uint64(FloatOverflowedInteger)
 			}
 		}
 	} else if found&isFloatOnlyFlag == 0 {
-		flags |= uint64(FloatOverflowedInteger)
+		floatTag |= uint64(FloatOverflowedInteger)
 	}
 
 	if pos > 1 && buf[0] == '0' && isNumberRune[buf[1]]&isFloatOnlyFlag == 0 {
 		// Float can only have have a leading 0 when followed by a period.
-		return TagEnd, 0, 0
+		return 0, 0
 	}
 	f64, err := strconv.ParseFloat(unsafeBytesToString(buf[:pos]), 64)
 	if err == nil {
-		return TagFloat, math.Float64bits(f64), flags
+		return floatTag, math.Float64bits(f64)
 	}
-	return TagEnd, 0, 0
+	return 0, 0
 }
 
 // unsafeBytesToString should only be used when we have control of b.

--- a/parse_number_test.go
+++ b/parse_number_test.go
@@ -31,8 +31,8 @@ func TestNumberIsValid(t *testing.T) {
 	// From: https://stackoverflow.com/a/13340826
 	var jsonNumberRegexp = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
 	isValidNumber := func(s string) bool {
-		tag, _, _ := parseNumber([]byte(s))
-		return tag != TagEnd
+		tag, _ := parseNumber([]byte(s))
+		return tag != 0
 	}
 	validTests := []string{
 		"0",

--- a/parsed_json.go
+++ b/parsed_json.go
@@ -962,8 +962,8 @@ func (pj *ParsedJson) writeTapeTagVal(tag Tag, val uint64) {
 	pj.Tape = append(pj.Tape, uint64(tag)<<56, val)
 }
 
-func (pj *ParsedJson) writeTapeTagValFlags(tag Tag, val, flags uint64) {
-	pj.Tape = append(pj.Tape, uint64(tag)<<56|flags, val)
+func (pj *ParsedJson) writeTapeTagValFlags(id, val uint64) {
+	pj.Tape = append(pj.Tape, id, val)
 }
 
 func (pj *ParsedJson) write_tape_s64(val int64) {


### PR DESCRIPTION
```
benchmark                                             old ns/op      new ns/op      delta
BenchmarkApache_builds/copy-32                        138493         138857         +0.26%
BenchmarkApache_builds/nocopy-32                      105770         100223         -5.24%
BenchmarkCanada/copy-32                               11324695       11046309       -2.46%
BenchmarkCanada/nocopy-32                             11322561       11141677       -1.60%
BenchmarkCitm_catalog/copy-32                         1560859        1387570        -11.10%
BenchmarkCitm_catalog/nocopy-32                       1202324        1244282        +3.49%
BenchmarkGithub_events/copy-32                        77414          70334          -9.15%
BenchmarkGithub_events/nocopy-32                      62410          58026          -7.02%
BenchmarkGsoc_2018/copy-32                            1259296        1240525        -1.49%
BenchmarkGsoc_2018/nocopy-32                          1020954        1028086        +0.70%
BenchmarkInstruments/copy-32                          336638         285133         -15.30%
BenchmarkInstruments/nocopy-32                        258841         253191         -2.18%
BenchmarkMarine_ik/copy-32                            12680069       12667499       -0.10%
BenchmarkMarine_ik/nocopy-32                          12128601       12184505       +0.46%
BenchmarkMesh/copy-32                                 3785664        3736734        -1.29%
BenchmarkMesh/nocopy-32                               3778827        3691958        -2.30%
BenchmarkMesh_pretty/copy-32                          4296619        4200696        -2.23%
BenchmarkMesh_pretty/nocopy-32                        4293104        4224935        -1.59%
BenchmarkNumbers/copy-32                              724006         720850         -0.44%
BenchmarkNumbers/nocopy-32                            723446         714401         -1.25%
BenchmarkRandom/copy-32                               1069045        974317         -8.86%
BenchmarkRandom/nocopy-32                             725070         720869         -0.58%
BenchmarkTwitter/copy-32                              621589         586054         -5.72%
BenchmarkTwitter/nocopy-32                            467495         450845         -3.56%
BenchmarkTwitterescaped/copy-32                       998509         944640         -5.39%
BenchmarkTwitterescaped/nocopy-32                     861515         852544         -1.04%
BenchmarkUpdate_center/copy-32                        713592         702087         -1.61%
BenchmarkUpdate_center/nocopy-32                      507995         510048         +0.40% 
```