### PR TITLE
fix error message that says "object" at `.Array()`

### DIFF
--- a/parsed_json.go
+++ b/parsed_json.go
@@ -1021,7 +1021,7 @@ func (i *Iter) Object(dst *Object) (*Object, error) {
 // An optional destination can be given.
 func (i *Iter) Array(dst *Array) (*Array, error) {
 	if i.t != TagArrayStart {
-		return nil, errors.New("next item is not object")
+		return nil, errors.New("next item is not array")
 	}
 	end := i.cur
 	if uint64(len(i.tape.Tape)) < end {


### PR DESCRIPTION
this can be pretty confusing when you're trying to find where the error was fired.