### PR TITLE
fix: Object.ForEach now continues the loop after consuming a skipped value

### DIFF
--- a/parsed_object.go
+++ b/parsed_object.go
@@ -169,6 +169,7 @@ func (o *Object) ForEach(fn func(key []byte, i Iter), onlyKeys map[string]struct
 				if t == TypeNone {
 					return nil
 				}
+				continue
 			}
 		}
 


### PR DESCRIPTION
This pull request fixes an issue in Object.ForEach that occurs when a non-nil onlyKeys map is provided. Specifically, if the current key isn't found in the map, the code correctly skips over its associated value but then fails to continue to the next iteration. As a result, the remainder of the loop runs and mistakenly consumes the subsequent key. This update ensures that the loop properly skips the rest of the current iteration when a key is absent.