### PR TITLE
Update NDJSON link to GitHub Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Compared to Golang's standard package `encoding/json`, `simdjson-go` is about 10
 Additionally `simdjson-go` has the following features:
 
 - No 4 GB object limit
-- Support for [ndjson](http://ndjson.org/) (newline delimited json)
+- Support for [ndjson](https://github.com/ndjson/ndjson-spec) (newline delimited json)
 - Pure Go (no need for cgo)
 - Object search/traversal.
 - In-place value replacement.


### PR DESCRIPTION
The domain has expired and is now serving a malware (https://github.com/ndjson/ndjson.github.io/issues/24), linked to the GitHub Specification of NDJSON directly